### PR TITLE
Add 401, 403, 404 middleware

### DIFF
--- a/swift_browser_ui/_convenience.py
+++ b/swift_browser_ui/_convenience.py
@@ -83,11 +83,7 @@ def check_csrf(request):
                     request.headers["Referer"]
                 )
             )
-            raise aiohttp.web.HTTPUnauthorized(
-                headers={
-                    "WWW-Authenticate": 'Bearer realm="/", charset="UTF-8"'
-                }
-            )
+            raise aiohttp.web.HTTPForbidden()
     else:
         request.app["Log"].debug(
             "Skipping referral validation due to missing Referer-header."
@@ -106,11 +102,7 @@ def check_csrf(request):
                 request.headers["Referer"]
             )
         )
-        raise aiohttp.web.HTTPUnauthorized(
-            headers={
-                "WWW-Authenticate": 'Bearer realm="/", charset="UTF-8"'
-            }
-        )
+        raise aiohttp.web.HTTPForbidden()
     # If all is well, return True.
     return True
 

--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -245,7 +245,7 @@ async def get_metadata(request):
     # contain sensitive data. This is not needed directly for the UI, but
     # the API is exposed for the user and thus can't expose any sensitive info
     if not meta_cont:
-        raise aiohttp.web.HTTPForbidden()
+        raise aiohttp.web.HTTPClientError()
 
     conn = request.app['Creds'][session]['ST_conn']
 

--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -245,7 +245,7 @@ async def get_metadata(request):
     # contain sensitive data. This is not needed directly for the UI, but
     # the API is exposed for the user and thus can't expose any sensitive info
     if not meta_cont:
-        raise aiohttp.web.HTTPUnauthorized()
+        raise aiohttp.web.HTTPForbidden()
 
     conn = request.app['Creds'][session]['ST_conn']
 

--- a/swift_browser_ui/front.py
+++ b/swift_browser_ui/front.py
@@ -10,7 +10,12 @@ async def browse(request):
     """Serve the browser SPA when running without a proxy."""
     session_check(request)
     response = aiohttp.web.FileResponse(
-        setd['static_directory'] + '/browse.html'
+        setd['static_directory'] + '/browse.html',
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0"
+        }
     )
     return response
 

--- a/swift_browser_ui/middlewares.py
+++ b/swift_browser_ui/middlewares.py
@@ -1,0 +1,50 @@
+"""Middlewares for the swift-browser-ui."""
+
+from aiohttp import web
+
+from .settings import setd
+
+
+@web.middleware
+async def unauthorized_middleware(request, handler):
+    """Return a custom page upon an HTTP 401."""
+    try:
+        response = await handler(request)
+        if response.status != 401:
+            return response
+    except web.HTTPException as ex:
+        if ex.status != 401:
+            raise
+    return web.FileResponse(
+        setd["static_directory"] + "/401.html"
+    )
+
+
+@web.middleware
+async def forbidden_middleware(request, handler):
+    """Return a custom page upon an HTTP 403."""
+    try:
+        response = await handler(request)
+        if response.status != 403:
+            return response
+    except web.HTTPException as ex:
+        if ex.status != 403:
+            raise
+    return web.FileResponse(
+        setd["static_directory"] + "/403.html"
+    )
+
+
+@web.middleware
+async def not_found_middleware(request, handler):
+    """Return a custom page upon an HTTP 404."""
+    try:
+        response = await handler(request)
+        if response.status != 404:
+            return response
+    except web.HTTPException as ex:
+        if ex.status != 404:
+            raise
+    return web.FileResponse(
+        setd["static_directory"] + "/404.html"
+    )

--- a/swift_browser_ui/middlewares.py
+++ b/swift_browser_ui/middlewares.py
@@ -6,45 +6,40 @@ from .settings import setd
 
 
 @web.middleware
-async def unauthorized_middleware(request, handler):
-    """Return a custom page upon an HTTP 401."""
+async def error_middleware(request, handler):
+    """Return the correct HTTP Error page."""
     try:
         response = await handler(request)
-        if response.status != 401:
-            return response
+        if response.status == 401:
+            return web.FileResponse(
+                setd["static_directory"] + "/401.html",
+                status=401
+            )
+        if response.status == 403:
+            return web.FileResponse(
+                setd["static_directory"] + "/403.html",
+                status=403
+            )
+        if response.status == 404:
+            return web.FileResponse(
+                setd["static_directory"] + "/404.html",
+                status=404
+            )
+        return response
     except web.HTTPException as ex:
-        if ex.status != 401:
-            raise
-    return web.FileResponse(
-        setd["static_directory"] + "/401.html"
-    )
-
-
-@web.middleware
-async def forbidden_middleware(request, handler):
-    """Return a custom page upon an HTTP 403."""
-    try:
-        response = await handler(request)
-        if response.status != 403:
-            return response
-    except web.HTTPException as ex:
-        if ex.status != 403:
-            raise
-    return web.FileResponse(
-        setd["static_directory"] + "/403.html"
-    )
-
-
-@web.middleware
-async def not_found_middleware(request, handler):
-    """Return a custom page upon an HTTP 404."""
-    try:
-        response = await handler(request)
-        if response.status != 404:
-            return response
-    except web.HTTPException as ex:
-        if ex.status != 404:
-            raise
-    return web.FileResponse(
-        setd["static_directory"] + "/404.html"
-    )
+        if ex.status == 401:
+            return web.FileResponse(
+                setd["static_directory"] + "/401.html",
+                status=401
+            )
+        if ex.status == 403:
+            return web.FileResponse(
+                setd["static_directory"] + "/403.html",
+                status=403
+            )
+        if ex.status == 404:
+            return web.FileResponse(
+                setd["static_directory"] + "/404.html",
+                status=404
+            )
+        raise

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -21,6 +21,9 @@ from .api import list_buckets, list_objects, download_object, os_list_projects
 from .api import get_os_user, get_os_active_project
 from .api import get_metadata, get_project_metadata
 from .settings import setd
+from .middlewares import unauthorized_middleware
+from .middlewares import forbidden_middleware
+from .middlewares import not_found_middleware
 
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -57,7 +60,13 @@ async def kill_sess_on_shutdown(app):
 
 async def servinit():
     """Create an aiohttp server with the correct arguments and routes."""
-    app = aiohttp.web.Application()
+    app = aiohttp.web.Application(
+        middlewares=[
+            unauthorized_middleware,
+            forbidden_middleware,
+            not_found_middleware,
+        ]
+    )
 
     # Mutable_map handles cookie storage, also stores the object that provides
     # the encryption we use

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -21,9 +21,7 @@ from .api import list_buckets, list_objects, download_object, os_list_projects
 from .api import get_os_user, get_os_active_project
 from .api import get_metadata, get_project_metadata
 from .settings import setd
-from .middlewares import unauthorized_middleware
-from .middlewares import forbidden_middleware
-from .middlewares import not_found_middleware
+from .middlewares import error_middleware
 
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -61,11 +59,7 @@ async def kill_sess_on_shutdown(app):
 async def servinit():
     """Create an aiohttp server with the correct arguments and routes."""
     app = aiohttp.web.Application(
-        middlewares=[
-            unauthorized_middleware,
-            forbidden_middleware,
-            not_found_middleware,
-        ]
+        middlewares=[error_middleware]
     )
 
     # Mutable_map handles cookie storage, also stores the object that provides

--- a/swift_browser_ui_frontend/401.html
+++ b/swift_browser_ui_frontend/401.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <!-- Maybe these should be bundled to conserve 3rd party -->
+    <!-- CDN bandwidth? (Also could be faster to self-host) -->
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.js"></script>
+    <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.css">
+    <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">
+    <script src="/static/js/lang.js"></script>
+    <link rel='stylesheet' href='/static/css/browse.css'>
+    <script src="/static/js/index.js"></script>
+    <title>Unauthorized</title>
+  </head>
+  <body>
+    <div id="app" class="hero is-fullheight">
+      <div class="hero-body">
+        <div class="container">
+          <div class="columns is-centered">
+            <div class="column is-4-desktop is-3-widescreen box" id="login-center">
+              <div class="columns is-centered">
+                <a href="#">
+                  <img src="/static/img/csc_logo.svg" :alt="$t('message.cscOrg')">
+                </a>
+              </div>
+              <div>
+                <b-message
+                  :title="$t('message.error.Unauthorized')"
+                  type="is-warning"
+                  has-icon
+                >{{ $t("message.error.Unauthorized_text") }}</b-message>
+              </div>
+              <div class="buttons">
+                <a class="button is-primary is-fullwidth" href="/login">{{ $t("message.index.logIn") }}</a>
+              </div>
+              <div class="buttons">
+                <a class="button is-primary is-fullwidth" href="/">{{ $t("message.error.frontPage") }}</a>
+              </div>
+              <b-field class="locale-changer">
+                <b-select placeholder="Language" icon="earth"
+                    v-model="$i18n.locale"
+                    v-on:input="setCookieLang ()"
+                    expanded>
+                  <option v-for="lang in langs" :key="lang.value" :value="lang.value">{{ lang.ph }}</option>
+                </b-select>
+              </b-field>
+              <footer class="footer">
+                <div class="content has-text-centered">
+                  <p>
+                    <strong>{{ $t("message.program_name") }}</strong> {{ $t("message.devel") }}
+                    <a href="https://csc.fi" :alt="$t('message.cscOrg')">{{ $t("message.cscOrg") }}</a>
+                  </p>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      app.$mount("#app")
+    </script>
+  </body>
+</html>

--- a/swift_browser_ui_frontend/403.html
+++ b/swift_browser_ui_frontend/403.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <!-- Maybe these should be bundled to conserve 3rd party -->
+    <!-- CDN bandwidth? (Also could be faster to self-host) -->
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.js"></script>
+    <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.css">
+    <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">
+    <script src="/static/js/lang.js"></script>
+    <link rel='stylesheet' href='/static/css/browse.css'>
+    <script src="/static/js/index.js"></script>
+    <title>Forbidden</title>
+  </head>
+  <body>
+    <div id="app" class="hero is-fullheight">
+      <div class="hero-body">
+        <div class="container">
+          <div class="columns is-centered">
+            <div class="column is-4-desktop is-3-widescreen box" id="login-center">
+              <div class="columns is-centered">
+                <a href="#">
+                  <img src="/static/img/csc_logo.svg" :alt="$t('message.cscOrg')">
+                </a>
+              </div>
+              <div>
+                <b-message
+                  :title="$t('message.error.Forbidden')"
+                  type="is-warning"
+                  has-icon
+                >{{ $t("message.error.Forbidden_text") }}</b-message>
+              </div>
+              <div class="buttons">
+                <a class="button is-primary is-fullwidth" href="/">{{ $t("message.error.frontPage") }}</a>
+              </div>
+              <b-field class="locale-changer">
+                <b-select placeholder="Language" icon="earth"
+                    v-model="$i18n.locale"
+                    v-on:input="setCookieLang ()"
+                    expanded>
+                  <option v-for="lang in langs" :key="lang.value" :value="lang.value">{{ lang.ph }}</option>
+                </b-select>
+              </b-field>
+              <footer class="footer">
+                <div class="content has-text-centered">
+                  <p>
+                    <strong>{{ $t("message.program_name") }}</strong> {{ $t("message.devel") }}
+                    <a href="https://csc.fi" :alt="$t('message.cscOrg')">{{ $t("message.cscOrg") }}</a>
+                  </p>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      app.$mount("#app")
+    </script>
+  </body>
+</html>

--- a/swift_browser_ui_frontend/404.html
+++ b/swift_browser_ui_frontend/404.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <!-- Maybe these should be bundled to conserve 3rd party -->
+    <!-- CDN bandwidth? (Also could be faster to self-host) -->
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.js"></script>
+    <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/buefy@0.7.8/dist/buefy.min.css">
+    <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">
+    <script src="/static/js/lang.js"></script>
+    <link rel='stylesheet' href='/static/css/browse.css'>
+    <script src="/static/js/index.js"></script>
+    <title>Not found</title>
+  </head>
+  <body>
+    <div id="app" class="hero is-fullheight">
+      <div class="hero-body">
+        <div class="container">
+          <div class="columns is-centered">
+            <div class="column is-4-desktop is-3-widescreen box" id="login-center">
+              <div class="columns is-centered">
+                <a href="#">
+                  <img src="/static/img/csc_logo.svg" :alt="$t('message.cscOrg')">
+                </a>
+              </div>
+              <div>
+                <b-message
+                  :title="$t('message.error.Notfound')"
+                  type="is-danger"
+                  has-icon
+                >{{ $t("message.error.Notfound_text") }}</b-message>
+              </div>
+              <div class="buttons">
+                <a class="button is-primary is-fullwidth" href="/">{{ $t("message.error.frontPage") }}</a>
+              </div>
+              <b-field class="locale-changer">
+                <b-select placeholder="Language" icon="earth"
+                    v-model="$i18n.locale"
+                    v-on:input="setCookieLang ()"
+                    expanded>
+                  <option v-for="lang in langs" :key="lang.value" :value="lang.value">{{ lang.ph }}</option>
+                </b-select>
+              </b-field>
+              <footer class="footer">
+                <div class="content has-text-centered">
+                  <p>
+                    <strong>{{ $t("message.program_name") }}</strong> {{ $t("message.devel") }}
+                    <a href="https://csc.fi" :alt="$t('message.cscOrg')">{{ $t("message.cscOrg") }}</a>
+                  </p>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      app.$mount("#app")
+    </script>
+  </body>
+</html>

--- a/swift_browser_ui_frontend/js/lang.js
+++ b/swift_browser_ui_frontend/js/lang.js
@@ -5,6 +5,15 @@ const langPlaceholders = {
             index: {
                 logIn: 'Log In',
             },
+            error: {
+                frontPage: 'To the Front Page',
+                Unauthorized: '401 – Not logged in',
+                Unauthorized_text: 'The action you want to take requires logging in. You can do so with the button below.',
+                Notfound: '404 – Could not find the page you were looking for.',
+                Notfound_text: 'The front page, however, can be found – in the link below.',
+                Forbidden: '403 – Wait, thats forbidden!',
+                Forbidden_text: 'You are forbidden from doing the previous request. If you are sure you should be allowed to perform said operation, contact the service administrator. Otherwise head back to the front page from the button below.',
+            },
             program_name: 'Object Browser',
             currentProj: 'Current project',
             logOut: 'Log Out',
@@ -60,6 +69,15 @@ const langPlaceholders = {
         message: {
             index: {
                 logIn: 'Kirjaudu sisään',
+            },
+            error: {
+                frontPage: 'Etusivulle',
+                Unauthorized: '401 – Kirjaudu sisään',
+                Unauthorized_text: 'Sivun näyttäminen vaatii sisäänkirjauksen, jonka voit toteuttaa oheisesta painikkeesta.',
+                Notfound: '404 – Etsimääsi sivua ei löydetty.',
+                Notfound_text: 'Etusivun voit löytää alapuolisesta painikkeesta.',
+                Forbidden: '403 – Tuo on kiellettyä.',
+                Forbidden_text: 'Se, mitä ikinä yrititkään äsken tehdä, ei ole sallittua. Mikäli olet sitä mieltä, että yrittämäsi pitäisi olla mahdollista, ota yhteys palvelun ylläpitäjään. Muussa tapauksessa palaa etusivulle oheisesta painikkeesta.',
             },
             program_name: 'Object Browser',
             currentProj: 'Nykyinen projekti',


### PR DESCRIPTION
### Description

Add custom error pages for common user related errors to improve user experience.

### Related issues

Solves issue #3.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

* Add middleware to the backend server to display custom localised error pages
* Prevent backtracking in page history after logout with correct cache settings

### Testing

- [x] Unit Tests
- [x] Integration 
