### PR TITLE
Add locust file for rudimentary API performance testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.com/CSCfi/swift-browser-ui.svg?branch=master)](https://travis-ci.com/CSCfi/swift-browser-ui)
 [![Coverage Status](https://coveralls.io/repos/github/CSCfi/swift-browser-ui/badge.svg?branch=master)](https://coveralls.io/github/CSCfi/swift-browser-ui?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/swift-browser-ui/badge/?version=latest)](https://swift-browser-ui.readthedocs.io/en/latest/?badge=latest)
+[![](https://images.microbadger.com/badges/image/cscfi/swift-ui.svg)](https://microbadger.com/images/cscfi/swift-ui "Get your own image badge on microbadger.com")
+
 
 ### Description
 
@@ -16,7 +18,8 @@ Project documentation is hosted on readthedocs: https://swift-browser-ui.rtfd.io
 Python 3.6+ required
 
 The dependencies mentioned in `requirements.txt` and an account that has access
-rights to CSC Pouta platform, and is taking part to at least one project as
+rights to [CSC Pouta](https://research.csc.fi/pouta-user-guide) platform, 
+and is taking part to at least one project as
 object stoarge is project specific.
 
 ### Usage

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = f'{current_year}, CSC Developers'
 author = 'CSC Developers'
 
 # The full version, including alpha/beta/rc tags
-version = release = '0.3.0'
+version = release = '0.3.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -15,7 +15,11 @@ Using vanilla docker in order to build the image - the tag can be customised:
 
     $ git clone https://github.com/CSCfi/swift-browser-ui/
     $ docker build -t cscfi/swift-ui .
-    $ docker run -p 5050:5050 cscfi/swift-ui
+    $ docker run -p 8080:8080 cscfi/swift-ui
+    $ # or with environment variables
+    $ docker run -p 8080:8080 \
+                 -e BROWSER_START_AUTH_ENDPOINT_URL=https://pouta.csc.fi:5001/v3 \
+                 cscfi/swift-ui
 
 
 

--- a/performance_tests/locustfile.py
+++ b/performance_tests/locustfile.py
@@ -1,0 +1,89 @@
+"""Locust file for testing the backend API performace."""
+
+from locust import HttpLocust, TaskSet
+
+
+def login(l_instance):
+    """Handle locust user login."""
+    l_instance.client.post(
+        "/login/websso",
+        {"token": "the_actual_token_doesn't_matter"}
+    )
+
+
+def logout(l_instance):
+    """Handle locust user logout."""
+    l_instance.client.get(
+        "/login/kill"
+    )
+
+
+def api_containers(l_instance):
+    """Get container listing."""
+    l_instance.client.get(
+        "/api/buckets"
+    )
+
+
+def api_objects(l_instance):
+    """Get object listing."""
+    l_instance.client.get(
+        "/api/objects?bucket=test-container-0"
+    )
+
+
+def api_active(l_instance):
+    """Get active project."""
+    l_instance.client.get(
+        "/api/active"
+    )
+
+
+def api_projects(l_instance):
+    """Get available projects."""
+    l_instance.client.get(
+        "/api/projects"
+    )
+
+
+def api_username(l_instance):
+    """Get the username."""
+    l_instance.client.get(
+        "/api/username"
+    )
+
+
+def api_project_meta(l_instance):
+    """Get the project metadata."""
+    l_instance.client.get(
+        "/api/get-project-meta"
+    )
+
+
+class UserBehaviour(TaskSet):
+    """Locust task class for swift-browser-ui user case."""
+
+    tasks = {
+        api_containers: 1,
+        api_objects: 5,
+        api_active: 1,
+        api_projects: 1,
+        api_username: 1,
+        api_project_meta: 2,
+    }
+
+    def on_start(self):
+        """Handle website login."""
+        login(self)
+
+    def on_stop(self):
+        """Handle website logout."""
+        logout(self)
+
+
+class APIUser(HttpLocust):
+    """Locust API user class."""
+
+    task_set = UserBehaviour
+    min_wait = 100
+    max_wait = 1000

--- a/swift_browser_ui/__init__.py
+++ b/swift_browser_ui/__init__.py
@@ -7,6 +7,6 @@ with the object storage.
 
 
 __name__ = 'swift_browser_ui'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'CSC Developers'
 __license__ = 'MIT License'

--- a/swift_browser_ui/_convenience.py
+++ b/swift_browser_ui/_convenience.py
@@ -140,12 +140,7 @@ def api_check(request):
     try:
         if decrypt_cookie(request)["id"] in request.app['Sessions']:
             session = decrypt_cookie(request)["id"]
-            if not check_csrf(request):
-                raise aiohttp.web.HTTPUnauthorized(
-                    headers={
-                        "WWW-Authenticate": 'Bearer realm="/", charset="UTF-8"'
-                    }
-                )
+            check_csrf(request)
             ret = session
             if 'ST_conn' not in request.app['Creds'][session].keys():
                 raise aiohttp.web.HTTPUnauthorized(

--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -62,7 +62,7 @@ async def swift_list_buckets(request):
         return aiohttp.web.json_response(cont)
 
     except SwiftError:
-        return aiohttp.web.json_response([])
+        raise aiohttp.web.HTTPNotFound()
 
 
 async def swift_list_objects(request):

--- a/tests/creation.py
+++ b/tests/creation.py
@@ -16,6 +16,30 @@ from swift_browser_ui._convenience import generate_cookie
 from .mockups import Mock_Request, Mock_Service, Mock_Session
 
 
+def add_csrf_to_cookie(cookie, req, bad_sign=False):
+    """Add specified csrf test variables to cookie."""
+    # Getting options as a set
+    cookie["referer"] = "http://localhost:8080"
+    if bad_sign:
+        cookie["signature"] = "incorrect"
+    else:
+        cookie["signature"] = (hashlib.sha256((cookie["id"] +
+                                               cookie["referer"] +
+                                               req.app["Salt"])
+                                              .encode('utf-8'))
+                               .hexdigest())
+    return cookie
+
+
+def encrypt_cookie(cookie, req):
+    """Add encrypted cookie to request."""
+    cookie_crypted = \
+        req.app["Crypt"].encrypt(
+            json.dumps(cookie).encode('utf-8')
+        ).decode('utf-8')
+    req.cookies["S3BROW_SESSION"] = cookie_crypted
+
+
 def get_request_with_fernet():
     """Create a request with a working fernet object."""
     ret = Mock_Request()

--- a/tests/mockups.py
+++ b/tests/mockups.py
@@ -226,6 +226,7 @@ class Mock_Service:
             size_range=(0, 0),
             container_name_prefix="test-container-",
             object_name_prefix=None,  # None for just the hash as name
+            has_content_type=None,
     ):
         """Initialize the Mock_Service instance with some test data."""
         for i in range(0, containers):
@@ -241,14 +242,17 @@ class Mock_Service:
                     oname = object_name_prefix + ohash
                 else:
                     oname = ohash
-                to_add.append({
+                to_append = {
                     "hash": ohash,
                     "name": oname,
                     "last_modified": datetime.datetime.now().isoformat(),
                     "bytes": random.randint(  # nosec
                         size_range[0], size_range[1]
-                    ),
-                })
+                    )
+                }
+                if has_content_type:
+                    to_append["content_type"] = has_content_type
+                to_add.append(to_append)
 
             self.containers[container_name_prefix + str(i)] = to_add
 
@@ -269,12 +273,15 @@ class Mock_Service:
             ret = []
             try:
                 for i in self.containers[container]:
-                    ret.append({
+                    to_append = {
                         "hash": i["hash"],
                         "name": i["name"],
                         "last_modified": i["last_modified"],
-                        "bytes": i["bytes"]
-                    })
+                        "bytes": i["bytes"],
+                    }
+                    if "content_type" in i.keys():
+                        to_append["content_type"] = i["content_type"]
+                    ret.append(to_append)
                 return [{
                     "listing": ret
                 }]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,7 +82,7 @@ class APITestClass(asynctest.TestCase):
         """Test function swift_list_objects with unicode nulls in type."""
         self.request.app["Creds"][self.cookie]["ST_conn"].init_with_data(
             containers=1,
-            object_range=(0, 10),
+            object_range=(1, 10),
             size_range=(65535, 262144),
             has_content_type="text/html",
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -373,5 +373,6 @@ class APITestClass(asynctest.TestCase):
         self.assertEqual(text, "placeholder")
 
     def tearDown(self):
+        """Test teardown."""
         self.cookie = None
         self.request = None

--- a/tests/test_convenience.py
+++ b/tests/test_convenience.py
@@ -126,10 +126,16 @@ class TestConvenienceFunctions(unittest.TestCase):
         with self.assertRaises(HTTPUnauthorized):
             api_check(testreq)
 
-    # NOTE: The order of operations for these tests is significant
-    # (i.e. there is a reason some of the placeholders are missing
-    # in the test functions,
-    # to enable testing correct raising order in the same time)
+    def test_api_check_raise_on_invalid_fernet(self):
+        """Test raise if the cryptographic key has changed."""
+        testreq = get_request_with_fernet()
+        _, testreq.cookies['S3BROW_SESSION'] = generate_cookie(testreq)
+        testreq.app['Crypt'] = cryptography.fernet.Fernet(
+            cryptography.fernet.Fernet.generate_key()
+        )
+        with self.assertRaises(HTTPUnauthorized):
+            api_check(testreq)
+
     def test_api_check_raise_on_no_connection(self):
         """Test raise if there's no existing OS connection on an API call."""
         testreq = get_request_with_fernet()
@@ -153,6 +159,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         session = cookie["id"]
         testreq.app['Sessions'] = [session]
         testreq.app['Creds'][session] = {}
+        testreq.app['Creds'][session]['ST_conn'] = "placeholder"
         testreq.app['Creds'][session]['Avail'] = "placeholder"
         with self.assertRaises(HTTPUnauthorized):
             api_check(testreq)
@@ -166,6 +173,8 @@ class TestConvenienceFunctions(unittest.TestCase):
         session = cookie["id"]
         testreq.app['Creds'][session] = {}
         testreq.app['Sessions'] = [session]
+        testreq.app['Creds'][session]['ST_conn'] = "placeholder"
+        testreq.app['Creds'][session]['OS_sess'] = "placeholder"
         with self.assertRaises(HTTPUnauthorized):
             api_check(testreq)
 

--- a/tests/test_front.py
+++ b/tests/test_front.py
@@ -1,0 +1,54 @@
+"""Module for testing ``swift_browser_ui.front``."""
+
+
+import unittest
+import os
+
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+
+from swift_browser_ui.server import servinit
+
+
+class FrontendTestCase(AioHTTPTestCase):
+    """Test frontend."""
+
+    async def get_application(self):
+        """Retrieve web Application for test."""
+        return await servinit()
+
+    @staticmethod
+    def return_true(_):
+        """."""
+        return True
+
+    @unittest_run_loop
+    async def test_browse(self):
+        """Test /browse handler."""
+        patch_setd = unittest.mock.patch("swift_browser_ui.front.setd", new={
+            "static_directory": os.getcwd() + "/swift_browser_ui_frontend"
+        })
+        patch_check = unittest.mock.patch(
+            "swift_browser_ui.front.session_check",
+            new=self.return_true
+        )
+        with patch_setd, patch_check:
+            response = await self.client.request("GET", "/browse")
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers["Content-type"],
+                             "text/html")
+
+    @unittest_run_loop
+    async def test_index(self):
+        """Test / handler."""
+        patch_setd = unittest.mock.patch("swift_browser_ui.front.setd", new={
+            "static_directory": os.getcwd() + "/swift_browser_ui_frontend"
+        })
+        patch_check = unittest.mock.patch(
+            "swift_browser_ui.front.session_check",
+            new=self.return_true
+        )
+        with patch_setd, patch_check:
+            response = await self.client.request("GET", "/")
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers["Content-type"],
+                             "text/html")


### PR DESCRIPTION
### Description

Added a locust file to run [locustio](https://locust.io/), when wanting to test the API performance on a test server. Can be used for e.g. stressing the backend while navigating the SPA, to test user experience under high load.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

* Add locustfile.py with example user behaviour.

### Testing

Locust can be run from the root directory with the command 
`locust -f performance_tests/locustfile.py --host=http://localhost:8080` if the test server is running on the local machine. Locustio has to be installed, of course.
- [x] Tests do apply.
