### PR TITLE
Feature/enable standalone ssl support

### DIFF
--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -55,11 +55,10 @@ For the Pouta production environment for testing unsecurely without trust::
 
 Setting up TLS termination proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The backend itself is not meant to be run as standalone in a production
-environment. Therefore in a running config a TLS termination proxy should be
-used to make the service secure. Setting up TLS termination is outside the
-scope of this documentation, but a few useful links are provided along with
-the necessary configs regarding this service. [#]_ [#]_
+The backend can be run in secure mode, i.e. with HTTPS enabled, but for
+scaling up a TLS termination proxy is recommended. Setting up TLS termination
+is outside the scope of this documentation, but a few useful links are
+provided along with the necessary configs regarding this service. [#]_ [#]_
 
 Scaling up the service
 ----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -68,6 +68,9 @@ The following command line arguments are available for server startup.
                                trusted_dashboards in the specified address.
     --set-origin-address TEXT  Set the address that the program will be
                                redirected to from WebSSO
+    --secure                   Enable secure running, i.e. enable HTTPS.
+    --ssl-cert-file TEXT       Specify the certificate to use with SSL.
+    --ssl-cert-key TEXT        Specify the certificate key to use with SSL.
     --help                     Show this message and exit.
 
 
@@ -81,5 +84,11 @@ The following command line arguments are available for server startup.
                                authentication endpoint, i.e. if the program has
                                been listed on the respective Openstack keystone
                                trusted_dashboard list. [#]_
+--secure                       Enable HTTPS on the server, to enable secure
+                               requests if there's no TLS termination proxy.
+--ssl-cert-file TEXT           Specify SSL certificate file. Required when
+                               running in secure mode.
+--ssl-cert-key TEXT            Specify SSL certificate key. Required when
+                               running in secure mode.
 
 .. [#] https://docs.openstack.org/keystone/pike/advanced-topics/federation/websso.html

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -131,6 +131,9 @@ def run_server_secure(app, cert_file, cert_key):
     While this function is incomplete, the project is safe to run in
     production only via a TLS termination proxy with e.g. NGINX.
     """
+    # The chiphers are from the Mozilla project wiki, as a recommendation for
+    # the most secure and up-to-date build.
+    # https://wiki.mozilla.org/Security/Server_Side_TLS
     logger = logging.getLogger("swift-browser-ui")
     logger.debug("Running server securely.")
     logger.debug("Setting up SSL context for the server.")

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -139,17 +139,18 @@ def run_server_secure(app, cert_file, cert_key):
     logger.debug("Setting up SSL context for the server.")
     sslcontext = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
     cipher_str = (
-        'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE' +
-        '-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-' +
-        'AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-' +
-        'SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-' +
-        'RSA-AES128-SHA256'
+        "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE" +
+        "-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA" +
+        "-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM" +
+        "-SHA256:DHE-RSA-AES256-GCM-SHA384"
     )
     logger.debug(
         "Setting following ciphers for SSL context: \n%s",
         cipher_str
     )
     sslcontext.set_ciphers(cipher_str)
+    sslcontext.options |= ssl.OP_NO_TLSv1
+    sslcontext.options |= ssl.OP_NO_TLSv1_1
     logger.debug("Loading cert chain.")
     sslcontext.load_cert_chain(cert_file, cert_key)
     aiohttp.web.run_app(

--- a/swift_browser_ui/shell.py
+++ b/swift_browser_ui/shell.py
@@ -10,7 +10,7 @@ import click
 
 from .__init__ import __version__
 from .settings import setd, set_key, FORMAT
-from .server import servinit, run_server_insecure
+from .server import servinit, run_server_insecure, run_server_secure
 from ._convenience import setup_logging as conv_setup_logging
 
 
@@ -92,6 +92,18 @@ def cli(verbose, debug, logfile):
 @click.option(
     '--set-session-devmode', is_flag=True, default=False, hidden=True,
 )
+@click.option(
+    '--secure', is_flag=True, default=False,
+    help="Enable secure running, i.e. enable HTTPS."
+)
+@click.option(
+    '--ssl-cert-file', default=None, type=str,
+    help="Specify the certificate to use with SSL."
+)
+@click.option(
+    '--ssl-cert-key', default=None, type=str,
+    help="Specify the certificate key to use with SSL."
+)
 def start(
         port,
         auth_endpoint_url,
@@ -99,6 +111,9 @@ def start(
         dry_run,
         set_origin_address,
         set_session_devmode,
+        secure,
+        ssl_cert_file,
+        ssl_cert_key,
 ):
     """Start the browser backend and server."""
     logging.debug(
@@ -129,8 +144,10 @@ def start(
     logging.debug(
         "Running settings directory:%s", str(setd)
     )
-    if not dry_run:
+    if not dry_run and not secure:
         run_server_insecure(servinit())
+    if not dry_run and secure:
+        run_server_secure(servinit(), ssl_cert_file, ssl_cert_key)
 
 
 def main():


### PR DESCRIPTION
### Description

Re-enabled (and made it working as well) TLS as an option on the backend and improved the testing coverage a bit.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes made

* Add back the `run_server_secure` -function
* Update the documentation concerning the TLS, to include the possibility to run the server securely when running stand-alone
* Added some additional tests for `server.py` module functions
* Added new environment variables and command line arguments for specifying the SSL/TLS certificate

### Testing

- [x] Unit Tests
