### PR TITLE
Fix incorrect status codes in error middleware.

### DIFF
--- a/swift_browser_ui/middlewares.py
+++ b/swift_browser_ui/middlewares.py
@@ -5,41 +5,40 @@ from aiohttp import web
 from .settings import setd
 
 
+def return_error_response(error_code):
+    """Return the correct error page with correct status code."""
+    with open(
+            setd["static_directory"] + "/" + str(error_code) + ".html"
+    ) as resp:
+        return web.Response(
+            body="".join(resp.readlines()),
+            status=error_code,
+            content_type="text/html",
+            headers={
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0"
+            }
+        )
+
+
 @web.middleware
 async def error_middleware(request, handler):
     """Return the correct HTTP Error page."""
     try:
         response = await handler(request)
         if response.status == 401:
-            return web.FileResponse(
-                setd["static_directory"] + "/401.html",
-                status=401
-            )
+            return return_error_response(401)
         if response.status == 403:
-            return web.FileResponse(
-                setd["static_directory"] + "/403.html",
-                status=403
-            )
+            return return_error_response(403)
         if response.status == 404:
-            return web.FileResponse(
-                setd["static_directory"] + "/404.html",
-                status=404
-            )
+            return return_error_response(404)
         return response
     except web.HTTPException as ex:
         if ex.status == 401:
-            return web.FileResponse(
-                setd["static_directory"] + "/401.html",
-                status=401
-            )
+            return return_error_response(401)
         if ex.status == 403:
-            return web.FileResponse(
-                setd["static_directory"] + "/403.html",
-                status=403
-            )
+            return return_error_response(403)
         if ex.status == 404:
-            return web.FileResponse(
-                setd["static_directory"] + "/404.html",
-                status=404
-            )
+            return return_error_response(404)
         raise

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -52,37 +52,37 @@ class MiddlewareTestClass(asynctest.TestCase):
         """Test 401 middleware when the 401 status is returned."""
         resp = await error_middleware(None, return_401_handler)
         self.assertEqual(resp.status, 401)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_401_exception(self):
         """Test 401 middleware when the 401 status is risen."""
         resp = await error_middleware(True, return_401_handler)
         self.assertEqual(resp.status, 401)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_403_return(self):
         """Test 403 middleware when the 403 status is returned."""
         resp = await error_middleware(None, return_403_handler)
         self.assertEqual(resp.status, 403)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_403_exception(self):
         """Test 403 middleware when the 403 status is risen."""
         resp = await error_middleware(True, return_403_handler)
         self.assertEqual(resp.status, 403)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_404_return(self):
         """Test 404 middleware when the 404 status is returned."""
         resp = await error_middleware(None, return_404_handler)
         self.assertEqual(resp.status, 404)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_404_exception(self):
         """Test 404 middlewrae when the 404 status is risen."""
         resp = await error_middleware(True, return_404_handler)
         self.assertEqual(resp.status, 404)
-        self.assertIsInstance(resp, FileResponse)
+        self.assertIsInstance(resp, Response)
 
     async def test_error_middleware_no_error(self):
         """Test the general error middleware with correct status."""

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pydocstyle==3.0.0
     flake8
     flake8-docstrings
-commands = flake8 .
+commands = flake8 swift_browser_ui tests ui_tests
 
 [testenv:docs]
 ; skip_install = true


### PR DESCRIPTION
### Description

Error middleware was overwriting the status codes set in
initialization of the aiohttp.web.FileResponse. Thus, a
custom "FileResponse" was made to fix this, while additionally
preventing the caching of the error responses with correct
headers.

### Related issues
Fixes #19 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

* Fix middleware incorrect status codes when handling errors.
* Prevent error responses from being cached.

### Testing

- [x] Tests do not apply.
