### PR TITLE
split bucket and object metadata APIs #35

### DIFF
--- a/docs/source/_static/api.yml
+++ b/docs/source/_static/api.yml
@@ -156,11 +156,34 @@ paths:
     get:
       tags:
         - API Endpoints
-      summary: Get container or object(s) metadata.
+      summary: Get container metadata.
       parameters:
       - name: container
         in: query
-        description: The container the metadata of which is to be queried, or the container in which the queried objects are.
+        description: The container the metadata of which is to be queried.
+        schema:
+          type: string
+          example: test-container-1
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Meta'
+        403:
+          description: Unauthorized
+        404:
+          description: Not Found
+  /bucket/object/meta:
+    get:
+      tags:
+        - API Endpoints
+      summary: Get object(s) metadata.
+      parameters:
+      - name: container
+        in: query
+        description: The container in which the queried objects are.
         schema:
           type: string
           example: test-container-1
@@ -181,7 +204,6 @@ paths:
           description: Unauthorized
         404:
           description: Not Found
-
 components:
   schemas:
 

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -19,7 +19,7 @@ from .login import sso_query_end
 from .login import token_rescope
 from .api import list_buckets, list_objects, download_object, os_list_projects
 from .api import get_os_user, get_os_active_project
-from .api import get_metadata, get_project_metadata
+from .api import get_metadata_object, get_metadata_bucket, get_project_metadata
 from .api import swift_list_shared_objects
 from .settings import setd
 from .middlewares import error_middleware
@@ -116,7 +116,8 @@ async def servinit():
         aiohttp.web.get('/api/username', get_os_user),
         aiohttp.web.get('/api/projects', os_list_projects),
         aiohttp.web.get('/api/project/active', get_os_active_project),
-        aiohttp.web.get('/api/bucket/meta', get_metadata),
+        aiohttp.web.get('/api/bucket/meta', get_metadata_bucket),
+        aiohttp.web.get('/api/bucket/object/meta', get_metadata_object),
         aiohttp.web.get('/api/project/meta', get_project_metadata),
     ])
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,7 +13,8 @@ from swiftclient.service import SwiftError
 from swift_browser_ui.api import get_os_user, os_list_projects
 from swift_browser_ui.api import swift_list_buckets, swift_list_objects
 from swift_browser_ui.api import swift_download_object
-from swift_browser_ui.api import get_metadata
+from swift_browser_ui.api import get_metadata_object
+from swift_browser_ui.api import get_metadata_bucket
 from swift_browser_ui.api import get_project_metadata
 from swift_browser_ui.api import get_os_active_project
 from swift_browser_ui.settings import setd
@@ -210,7 +211,7 @@ class APITestClass(asynctest.TestCase):
         # Set up the query string
         self.request.query["container"] = "test-container-0"
 
-        resp = await get_metadata(self.request)
+        resp = await get_metadata_bucket(self.request)
         resp = json.loads(resp.text)
 
         expected = [  # nosec
@@ -248,7 +249,7 @@ class APITestClass(asynctest.TestCase):
         self.request.query["container"] = "test-container-0"
         self.request.query["object"] = objkey
 
-        resp = await get_metadata(self.request)
+        resp = await get_metadata_object(self.request)
         resp = json.loads(resp.text)
         expected = [[
             objkey, {"obj-example": "example"}
@@ -285,7 +286,7 @@ class APITestClass(asynctest.TestCase):
         self.request.query["container"] = "test-container-0"
         self.request.query["object"] = objkey
 
-        resp = await get_metadata(self.request)
+        resp = await get_metadata_object(self.request)
         resp = json.loads(resp.text)
 
         expected = [[  # nosec
@@ -330,7 +331,7 @@ class APITestClass(asynctest.TestCase):
             "%s,%s,%s,%s,%s" % tuple([i["name"] for i in objs])
         )
 
-        resp = await get_metadata(self.request)
+        resp = await get_metadata_object(self.request)
         resp = json.loads(resp.text)
 
         comp = [


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Split metadata API for containers and objects.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #35 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

<!-- List changes made. -->
1. split `get_metadata` into `get_metadata_object` and `get_metadata_bucket`
2. fixed tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
This might break some functionality, to test more.
