### PR TITLE
Fix docker build process after adding sharing support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN apk add --update \
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
 
-RUN cd /root/swift_ui/swift_browser_ui_frontend \\
-    && npm install \\
+RUN cd /root/swift_ui/swift_browser_ui_frontend \
+    && git clone --verbose https://github.com/CSCfi/swift-x-account-sharing.git \
+    && cp swift-x-account-sharing/bindings/js/swift_x_account_sharing_bind.js src/common/swift_x_account_sharing_bind.js \
+    && rm -rf swift-x-account-sharing \
+    && npm install \
     && npm run build
 
 FROM python:3.7-alpine3.9 as BACKEND


### PR DESCRIPTION
### Description
Docker build process broke after adding container sharing support as an import from another repository. This no longer breaks the build process.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
* Add fetching JS bindings from swift-x-account-sharing repo to Dockerfile

### Testing
- [x] Tests do not apply
