### PR TITLE
v0.6.2 Fix typo in settings.py preventing WebSSO

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = f'{current_year}, CSC Developers'
 author = 'CSC Developers'
 
 # The full version, including alpha/beta/rc tags
-version = release = '0.6.1'
+version = release = '0.6.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/swift_browser_ui/__init__.py
+++ b/swift_browser_ui/__init__.py
@@ -7,6 +7,6 @@ with the object storage.
 
 
 __name__ = 'swift_browser_ui'
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 __author__ = 'CSC Developers'
 __license__ = 'MIT License'

--- a/swift_browser_ui/settings.py
+++ b/swift_browser_ui/settings.py
@@ -73,7 +73,7 @@ setd = {
     "has_trust": environ.get(
         "BROWSER_START_HAS_TRUST", False
     ),
-    "set_origin_access": environ.get(
+    "set_origin_address": environ.get(
         "BROWSER_START_SET_ORIGIN_ADDRESS", None
     ),
     "logfile": None,

--- a/swift_browser_ui_frontend/package.json
+++ b/swift_browser_ui_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift_browser_ui_frontend_npm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "prepare": "git clone https://github.com/CSCfi/swift-x-account-sharing.git && cp swift-x-account-sharing/bindings/js/swift_x_account_sharing_bind.js src/common && rm -rf swift-x-account-sharing && git clone https://github.com/CSCfi/swift-sharing-request.git && cp swift-sharing-request/bindings/js/swift_sharing_request_bind.js src/common && rm -rf swift-sharing-request",


### PR DESCRIPTION
### Description

Typo in setting.py dictionary keys was preventing launch with WebSSO enabled.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

* Fix typo in `settings.py` `set_origin_access -> set_origin_address`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
