### PR TITLE
Reposition buttons

### DIFF
--- a/swift_browser_ui_frontend/src/pages/Browser.vue
+++ b/swift_browser_ui_frontend/src/pages/Browser.vue
@@ -76,7 +76,12 @@ html, body {
 
 .searchBox {
     width: 30%;
+    margin-right: auto;
     margin-left: auto;
+}
+
+.uploadGroup {
+  margin-left: auto;
 }
 
 .groupControls {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -39,13 +39,15 @@
           {{ $t('message.table.paginated') }}
         </b-switch>
       </div>
-      <FolderUploadForm dropelement="container-table" />
       <b-field class="control searchBox">
         <b-input
           v-model="searchQuery"
           :placeholder="$t('message.searchBy')"
         />
-      </b-field>      
+      </b-field>
+      <div class="field has-addons uploadGroup">
+        <FolderUploadForm dropelement="container-table" />
+      </div>
     </b-field>
     <b-table
       focusable

--- a/swift_browser_ui_frontend/src/views/Objects.vue
+++ b/swift_browser_ui_frontend/src/views/Objects.vue
@@ -39,7 +39,13 @@
           {{ $t('message.table.paginated') }}
         </b-switch>
       </div>
-      <div class="field has-addons">
+      <b-field class="control searchBox">
+        <b-input
+          v-model="searchQuery"
+          :placeholder="$t('message.searchBy')"
+        />
+      </b-field>
+      <div class="field has-addons uploadGroup">
         <p class="control">
           <FolderUploadForm dropelement="object-table" />
         </p>
@@ -55,7 +61,7 @@
           v-model="searchQuery"
           :placeholder="$t('message.searchBy')"
         />
-      </b-field>
+    </b-field>
     </b-field>
     <b-table
       focusable

--- a/swift_browser_ui_frontend/src/views/Objects.vue
+++ b/swift_browser_ui_frontend/src/views/Objects.vue
@@ -56,12 +56,6 @@
           <ReplicateContainerButton />
         </p>
       </div>
-      <b-field class="control searchBox">
-        <b-input
-          v-model="searchQuery"
-          :placeholder="$t('message.searchBy')"
-        />
-    </b-field>
     </b-field>
     <b-table
       focusable
@@ -107,38 +101,50 @@
           label=""
           width="110"
         >
-          <a
+          <b-button
             v-if="props.row.bytes < 1073741824"
             :href="props.row.url"
             target="_blank"
             :alt="$t('message.downloadAlt') + ' ' + props.row.name"
+            type="is-primary"
+            outlined
+            size="is-small"
+            tag="a"
           >
             <b-icon
               icon="download"
               size="is-small"
             /> {{ $t('message.download') }}
-          </a>
-          <a
+          </b-button>
+          <b-button
             v-else-if="allowLargeDownloads"
             :href="props.row.url"
             target="_blank"
             :alt="$t('message.downloadAlt') + ' ' + props.row.name"
+            type="is-primary"
+            outlined
+            size="is-small"
+            tag="a"
           >
             <b-icon
               icon="download"
               size="is-small"
             /> {{ $t('message.download') }}
-          </a>
-          <a
+          </b-button>
+          <b-button
             v-else
             :alt="$t('message.downloadAltLarge') + ' ' + props.row.name"
             @click="confirmDownload ()"
+            type="is-primary"
+            outlined
+            size="is-small"
+            tag="a"
           >
             <b-icon
               icon="download"
               size="is-small"
             /> {{ $t('message.download') }}
-          </a>
+          </b-button>
         </b-table-column>
       </template>
       <template

--- a/swift_browser_ui_frontend/src/views/SharedObjects.vue
+++ b/swift_browser_ui_frontend/src/views/SharedObjects.vue
@@ -31,7 +31,7 @@
           100 {{ $t('message.table.pageNb') }}
         </option>
       </b-select>
-      <div class="field has-addons">
+      <div class="field has-addons uploadGroup">
         <p class="control">
           <ContainerDownloadLink />
         </p>

--- a/swift_browser_ui_frontend/src/views/Sharing.vue
+++ b/swift_browser_ui_frontend/src/views/Sharing.vue
@@ -4,9 +4,9 @@
     class="contents"
   >
     <form action="">
-      <div>
+      <div class="contents">
         <header>
-          <h1 class="title sharinghead">
+          <h1 class="title is-3 sharinghead">
             {{ $t('message.share.share_cont') }}
           </h1>
         </header>
@@ -69,7 +69,6 @@
 <style scoped>
   #sharingview {
     width: auto;
-    margin-top: 2%;
     margin-left: 5%;
     margin-right: 5%;
   }
@@ -83,7 +82,7 @@
   }
 
   .sharinghead {
-    margin: 1%;
+    margin: 1% 1% 1% 0;
   }
 </style>
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Fixes some visual cues for grouping functionality.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

Just usability concerns

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
New position of the button and upload button:
![image](https://user-images.githubusercontent.com/47524/79778441-6642fb00-8341-11ea-84a3-e365a18c3f62.png)

New position of upload + download container group also new download button:
![image](https://user-images.githubusercontent.com/47524/79778528-84106000-8341-11ea-83b9-4d35fc2cc485.png)

Adding to the `share the container` view a bit more eye-candy positioning 

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply
