### PR TITLE
Calculate BU close to zero

### DIFF
--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -138,8 +138,15 @@ export async function getProjectMeta () {
     .then( function ( json_ret ) {
       let newRet = json_ret;
       newRet["Size"] = getHumanReadableSize(newRet["Bytes"]);
-      newRet["Billed"] = parseFloat(newRet["Bytes"] / 1099511627776 * 3.5)
-        .toPrecision(4);
+      // we check if it is greather than 0.4Mib if not we display with 10
+      // decimal points
+      if (newRet["Bytes"] > 400000) {
+        newRet["Billed"] = parseFloat(newRet["Bytes"] / 1099511627776 * 3.5)
+          .toPrecision(4);
+      } else {
+        newRet["Billed"] = parseFloat(newRet["Bytes"] / 1099511627776 * 3.5)
+          .toFixed(10);
+      }
       return newRet;
     });
   return ret;

--- a/swift_browser_ui_frontend/src/components/FolderUpload.vue
+++ b/swift_browser_ui_frontend/src/components/FolderUpload.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <b-button
+      v-if="isUploading"
       type="is-primary"
       outlined
-      v-if="isUploading"
       @click="res.cancel()"
     >
       <b-icon


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
We display 0 BU if the used bytes are less than 0.4Mib we display with fixed 10 decimal points to get some relevant information.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
closes #52

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->
1. add a check for bytes size less than 0.4mb
2. display with fixed decimals
3. one fix by `npm lint`
### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply
