### PR TITLE
Feature/switch to python secrets

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,8 @@ extensions = ['sphinx.ext.autodoc',
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+linkcheck_ignore = [r'https://editor.swagger.io/']
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.

--- a/swift_browser_ui/login.py
+++ b/swift_browser_ui/login.py
@@ -28,7 +28,11 @@ async def handle_login(
 
     # Add a cookie for navigating
     if "navto" in request.query.keys():
-        response.set_cookie("NAV_TO", request.query["navto"], expires=3600)
+        response.set_cookie(
+            "NAV_TO",
+            request.query["navto"],
+            expires=str(3600)
+        )
 
     response.headers['Location'] = "/login/front"
 
@@ -40,7 +44,7 @@ async def sso_query_begin(_) -> aiohttp.web.Response:
     # Return the form based login page if the service isn't trusted
     if not setd['has_trust']:
         response = aiohttp.web.FileResponse(
-            setd['static_directory'] + '/login.html'
+            str(setd['static_directory']) + '/login.html'
         )
         return disable_cache(response)
 
@@ -142,7 +146,7 @@ async def sso_query_end(
         value=cookie_crypted,
         max_age=3600,
     )
-    request.app['Sessions'].append(session)
+    request.app['Sessions'].add(session)
     # Initiate the credential dictionary
     request.app['Creds'][session] = {}
 

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -5,10 +5,9 @@ import logging
 import time
 import sys
 import asyncio
-import hashlib
-import os
 import ssl
 import typing
+import secrets
 
 import uvloop
 import cryptography.fernet
@@ -121,12 +120,12 @@ async def servinit() -> aiohttp.web.Application:
     # Create a signature salt to prevent editing the signature on the client
     # side. Hash function doesn't need to be cryptographically secure, it's
     # just a convenient way of getting ascii output from byte values.
-    app['Salt'] = hashlib.md5(os.urandom(128)).hexdigest()  # nosec
+    app['Salt'] = secrets.token_hex(64)
     # Set application specific logging
     app['Log'] = logging.getLogger('swift-browser-ui')
     app['Log'].info('Set up logging for the swift-browser-ui application')
-    # Session list to quickly validate sessions
-    app['Sessions'] = []
+    # Session set to quickly validate sessions
+    app['Sessions'] = set({})
     # Cookie keyed dictionary to store session data
     app['Creds'] = {}
 

--- a/swift_browser_ui/signature.py
+++ b/swift_browser_ui/signature.py
@@ -3,9 +3,8 @@
 
 import hmac
 import time
-import hashlib
-import os
 import logging
+import secrets
 
 import aiohttp.web
 
@@ -48,7 +47,7 @@ async def handle_ext_token_create(
     LOGGER.debug(f"Creating a scoped API token for {project}")
 
     ident = request.match_info["id"]
-    token = hashlib.sha256(os.urandom(256)).hexdigest()  # nosec
+    token = secrets.token_hex(64)
 
     client: aiohttp.ClientSession = request.app["api_client"]
 

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -162,6 +162,13 @@ const translations = {
         identLabel: "New token identifier",
         identMessage: "Insert new token identifier here",
         createToken: "Create token",
+        latestToken: "Latest token: ",
+        copyToken: "The token will be displayed just this once after its " +
+                   "creation, and recovering it will not be possible " +
+                   "afterwards. Please make sure that you have stored " +
+                   "the token somewhere before navigating away from the " +
+                   "token page.",
+        tokenCopied: "Token copied.",
       },
     },
   },
@@ -325,6 +332,12 @@ const translations = {
         identLabel: "Uuden avaimen tunniste",
         identMessage: "Syötä tunniste uudelle API-avaimelle",
         createToken: "Luo avain",
+        latestToken: "Viimeisin avain: ",
+        copyToken: "Avain näytetään vain kerran luonnin jälkeen, eikä sen " +
+                   "kopiointi tai palautus jälkeenpäin ole mahdollista. " +
+                   "Varmistathan ottaneesi avaimen talteen ennen " +
+                   "navigointia pois sivulta.",
+        tokenCopied: "Avain kopioitu.",
       },
     },
   },

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -60,12 +60,12 @@
       </div>
     </b-field>
     <b-table
+      class="objectTable"
       focusable
       detailed
       hoverable
       narrowed
       header-checkable
-      style="width: 90%;margin-left: 5%; margin-right: 5%;"
       default-sort="name"
       :data="oList"
       :selected.sync="selected"
@@ -252,15 +252,28 @@
         </span>
       </template>
       <template slot="empty">
-        <p
-          style="width:100%;text-align:center;margin-top:5%;margin-bottom:5%"
-        >
+        <p class="emptyTable">
           {{ $t('message.emptyContainer') }}
         </p>
       </template>
     </b-table>
   </div>
 </template>
+
+<style scoped>
+.objectTable {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+
+.emptyTable {
+  width: 100%;
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
+}
+</style>
 
 <script>
 import {

--- a/swift_browser_ui_frontend/src/components/ShareRequestsTable.vue
+++ b/swift_browser_ui_frontend/src/components/ShareRequestsTable.vue
@@ -79,9 +79,7 @@
         </b-table-column>
       </template>
       <template slot="empty">
-        <p
-          style="text-align:center;margin-top:5%;margin-bottom:5%"
-        >
+        <p class="empptyTable">
           {{ $t('message.emptyRequested') }}
         </p>
       </template>
@@ -92,6 +90,11 @@
 <style scoped>
 #requested-shares-table {
   margin-top: 20px;
+}
+.emptyTable {
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
 }
 </style>
 

--- a/swift_browser_ui_frontend/src/components/SharedOutTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedOutTable.vue
@@ -113,9 +113,7 @@
         />
       </template>
       <template slot="empty">
-        <p
-          style="text-align:center;margin-top:5%;margin-bottom:5%"
-        >
+        <p class="emptyTable">
           {{ $t('message.emptyShared') }}
         </p>
       </template>
@@ -126,6 +124,11 @@
 <style scoped>
 #shared-out-table {
   width: 100%;
+}
+.emptyTable {
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
 }
 </style>
 

--- a/swift_browser_ui_frontend/src/components/SharedTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedTable.vue
@@ -105,9 +105,7 @@
         </b-table-column>
       </template>
       <template slot="empty">
-        <p
-          style="text-align:center;margin-top:5%;margin-bottom:5%"
-        >
+        <p class="emptyTable">
           {{ $t('message.emptyShared') }}
         </p>
       </template>
@@ -118,6 +116,11 @@
 <style scoped>
 #shared-table {
   width: 100%;
+}
+.emptyTable {
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
 }
 </style>
 

--- a/swift_browser_ui_frontend/src/components/Sharing.vue
+++ b/swift_browser_ui_frontend/src/components/Sharing.vue
@@ -1,8 +1,8 @@
 <template>
   <form action="">
     <div
+      id="sharingMenu"
       class="modal-card"
-      style="width: auto;"
     >
       <header class="modal-card-head">
         <p class="modal-card-title">
@@ -48,6 +48,12 @@
     </div>
   </form>
 </template>
+
+<style scoped>
+#sharingMenu {
+  width: auto;
+}
+</style>
 
 <script>
 export default {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -50,10 +50,10 @@
       </div>
     </b-field>
     <b-table
+      class="containerTable"
       focusable
       hoverable
       narrowed
-      style="width: 90%;margin-left: 5%; margin-right: 5%;"
       default-sort="name"
       :data="bList"
       :selected.sync="selected"
@@ -174,15 +174,26 @@
         </b-table-column>
       </template>
       <template slot="empty">
-        <p
-          style="text-align:center;margin-top:5%;margin-bottom:5%;"
-        >
+        <p class="emptyTable">
           {{ $t('message.emptyProject') }}
         </p>
       </template>
     </b-table>
   </div>
 </template>
+
+<style scoped>
+.containerTable {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+.emptyTable {
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
+}
+</style>
 
 <script>
 import { getHumanReadableSize } from "@/common/conv";

--- a/swift_browser_ui_frontend/src/views/Replicate.vue
+++ b/swift_browser_ui_frontend/src/views/Replicate.vue
@@ -1,7 +1,7 @@
 <template>
   <div
+    id="replicateView"
     class="contents"
-    style="width: 90%;"
   >
     <b-field grouped>
       <b-field
@@ -30,7 +30,7 @@
           </button>
           <span
             v-if="destinationExists"
-            style="margin-top: auto;margin-bottom: auto;"
+            class="forbiddenDestination"
           >
             {{ $t('message.replicate.destinationExists') }}
           </span>
@@ -48,6 +48,13 @@
 </template>
 
 <style scoped>
+.forbiddenDestination {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+#replicateView {
+  width: 90%;
+}
 #destinationButton {
   display: flex;
   justify-content: center;

--- a/swift_browser_ui_frontend/src/views/Shared.vue
+++ b/swift_browser_ui_frontend/src/views/Shared.vue
@@ -2,9 +2,9 @@
   <div id="shared-tabs">
     <b-tabs
       v-model="activeTab"
+      class="sharedTab"
       type="is-toggle"
       expanded
-      style="width:90%;margin-left:5%;margin-right:5%;"
     >
       <b-tab-item
         :label="$t('message.share.to_me')"
@@ -26,6 +26,14 @@
     </b-tabs>
   </div>
 </template>
+
+<style scoped>
+.sharedTab {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+</style>
 
 <script>
 // Import table for the containers shared to the querying user

--- a/swift_browser_ui_frontend/src/views/Tokens.vue
+++ b/swift_browser_ui_frontend/src/views/Tokens.vue
@@ -41,7 +41,19 @@
       v-if="latest"
       class="tokenContents"
     >
-      <b>Latest token: </b> {{ latest }}
+      <div class="latestTokenRow">
+        <span>
+          <b>{{ $t('message.tokens.latestToken') }}</b>&nbsp;{{ latest }}&nbsp;
+        </span>
+        <b-button
+          class="copyButton"
+          outlined
+          icon-left="content-copy"
+          @click="copyTokenHex()"
+        >
+          {{ $t('message.copy') }}
+        </b-button>
+      </div>
     </div>
     <b-table
       class="tokenContents"
@@ -111,6 +123,14 @@
   margin-top: 5%;
   margin-bottom: 5%;
 }
+.latestTokenRow {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+}
+.copyButton {
+  margin-left: 1%;
+}
 </style>
 
 <script>
@@ -144,15 +164,28 @@ export default {
     addToken: function (identifier) {
       createExtToken(identifier).then((ret) => {
         this.latest = ret;
-        this.$buefy.toast.open({
-          message: "Copy the token displayed below identifier field",
+        this.$buefy.notification.open({
+          message: this.$t("message.tokens.copyToken"),
+          duration: 3600000,
           type: "is-success",
+          queue: false,
         });
         this.getTokens();
       });
     },
     tokenExists: function (identifier) {
       return this.tokens.includes(identifier) ? true : false;
+    },
+    copyTokenHex: function () {
+      navigator.clipboard.writeText(
+        this.latest,
+      ).then(() => {
+        this.$buefy.toast.open({
+          message: this.$t("message.tokens.tokenCopied"),
+          type: "is-success",
+          queue: false,
+        });
+      });
     },
   },
 };

--- a/swift_browser_ui_frontend/src/views/Tokens.vue
+++ b/swift_browser_ui_frontend/src/views/Tokens.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="contents">
-    <div style="width: 90%;margin-left: 5%; margin-right: 5%;">
+    <div class="tokenContents">
       <b-field grouped>
         <b-field
           horizontal
@@ -39,13 +39,13 @@
     </div>
     <div
       v-if="latest"
-      style="width: 90%;margin-left: 5%; margin-right: 5%;"
+      class="tokenContents"
     >
       <b>Latest token: </b> {{ latest }}
     </div>
     <b-table
+      class="tokenContents"
       narrowed
-      style="width: 90%;margin-left: 5%; margin-right: 5%;"
       default-sort="identifier"
       :data="tokens"
       :selected.sync="selected"
@@ -91,11 +91,27 @@
         </b-table-column>
       </template>
       <template slot="empty">
-        {{ $t('message.tokens.empty') }}
+        <span class="emptyContents">
+          {{ $t('message.tokens.empty') }}
+        </span>
       </template>
     </b-table>
   </div>
 </template>
+
+<style scoped>
+.tokenContents {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+.emptyContents {
+  width: 100%;
+  text-align: center;
+  margin-top: 5%;
+  margin-bottom: 5%;
+}
+</style>
 
 <script>
 import {

--- a/tests/unit/creation.py
+++ b/tests/unit/creation.py
@@ -43,7 +43,7 @@ def encrypt_cookie(cookie, req):
 def get_request_with_fernet():
     """Create a request with a working fernet object."""
     ret = Mock_Request()
-    ret.app['Sessions'] = []
+    ret.app['Sessions'] = set({})
     ret.app['Creds'] = {}
     ret.app['Log'] = logging.getLogger(name="test_logger")
     ret.app['Crypt'] = cryptography.fernet.Fernet(
@@ -66,7 +66,7 @@ def get_request_with_mock_openstack():
     ret.cookies["S3BROW_SESSION"] = ret.app["Crypt"].encrypt(
         json.dumps(cookie).encode('utf-8')
     ).decode('utf-8')
-    ret.app['Sessions'].append(session)
+    ret.app['Sessions'].add(session)
     ret.app['Creds'][session] = {}
     ret.app['Creds'][session]['OS_sess'] = Mock_Session()
     ret.app['Creds'][session]['ST_conn'] = Mock_Service()

--- a/tests/unit/test_convenience.py
+++ b/tests/unit/test_convenience.py
@@ -87,7 +87,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         """
         req = get_request_with_fernet()
         _, req.cookies['S3BROW_SESSION'] = generate_cookie(req)
-        req.app['Sessions'] = []
+        req.app['Sessions'] = set({})
         with self.assertRaises(HTTPUnauthorized):
             session_check(req)
 
@@ -103,7 +103,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         req.cookies['S3BROW_SESSION'] = \
             get_full_crypted_session_cookie(cookie, req.app)
 
-        req.app['Sessions'].append(cookie["id"])
+        req.app['Sessions'].add(cookie["id"])
         self.assertTrue(session_check(req) is None)
 
     # The api_check session check function testing – Might seem unnecessary,
@@ -114,7 +114,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         """Test raise if there's no session cookie."""
         testreq = get_request_with_fernet()
         _, testreq.cookies['S3BROW_SESSION'] = generate_cookie(testreq)
-        testreq.app['Sessions'] = []
+        testreq.app['Sessions'] = set({})
         with self.assertRaises(HTTPUnauthorized):
             api_check(testreq)
 
@@ -122,7 +122,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         """Test raise if there's an invalid session cookie."""
         testreq = get_request_with_fernet()
         _, testreq.cookies['S3BROW_SESSION'] = generate_cookie(testreq)
-        testreq.app['Sessions'] = []
+        testreq.app['Sessions'] = set({})
         with self.assertRaises(HTTPUnauthorized):
             api_check(testreq)
 
@@ -143,7 +143,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         testreq.cookies['S3BROW_SESSION'] = \
             get_full_crypted_session_cookie(cookie, testreq.app)
         session = cookie["id"]
-        testreq.app['Sessions'] = [session]
+        testreq.app['Sessions'] = {session}
         testreq.app['Creds'][session] = {}
         testreq.app['Creds'][session]['Avail'] = "placeholder"
         testreq.app['Creds'][session]['OS_sess'] = "placeholder"
@@ -157,7 +157,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         testreq.cookies['S3BROW_SESSION'] = \
             get_full_crypted_session_cookie(cookie, testreq.app)
         session = cookie["id"]
-        testreq.app['Sessions'] = [session]
+        testreq.app['Sessions'] = {session}
         testreq.app['Creds'][session] = {}
         testreq.app['Creds'][session]['ST_conn'] = "placeholder"
         testreq.app['Creds'][session]['Avail'] = "placeholder"
@@ -172,7 +172,7 @@ class TestConvenienceFunctions(unittest.TestCase):
             get_full_crypted_session_cookie(cookie, testreq.app)
         session = cookie["id"]
         testreq.app['Creds'][session] = {}
-        testreq.app['Sessions'] = [session]
+        testreq.app['Sessions'] = {session}
         testreq.app['Creds'][session]['ST_conn'] = "placeholder"
         testreq.app['Creds'][session]['OS_sess'] = "placeholder"
         with self.assertRaises(HTTPUnauthorized):
@@ -185,7 +185,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         testreq.cookies['S3BROW_SESSION'] = \
             get_full_crypted_session_cookie(cookie, testreq.app)
         session = cookie["id"]
-        testreq.app['Sessions'] = [session]
+        testreq.app['Sessions'] = {session}
         testreq.app['Creds'][session] = {}
         testreq.app['Creds'][session]['Avail'] = "placeholder"
         testreq.app['Creds'][session]['OS_sess'] = "placeholder"

--- a/tests/unit/test_login.py
+++ b/tests/unit/test_login.py
@@ -100,7 +100,7 @@ class LoginTestClass(asynctest.TestCase):
 
             # Test for the correct values
             assert req.app['Sessions']  # nosec
-            session = req.app['Sessions'][0]
+            session = list(req.app['Sessions'])[0]
             self.assertTrue(req.app['Creds'][session]['Token'] is not None)
             self.assertNotEqual(req.app['Creds'][session]['Avail'], "INVALID")
             self.assertEqual(req.app['Creds'][session]['active_project'], {
@@ -148,7 +148,7 @@ class LoginTestClass(asynctest.TestCase):
 
             # Test for the correct values
             assert req.app['Sessions']  # nosec
-            session = req.app['Sessions'][0]
+            session = list(req.app['Sessions'])[0]
             self.assertTrue(req.app['Creds'][session]['Token'] is not None)
             self.assertNotEqual(req.app['Creds'][session]['Avail'], "INVALID")
             self.assertEqual(req.app['Creds'][session]['active_project'], {
@@ -196,7 +196,7 @@ class LoginTestClass(asynctest.TestCase):
 
             # Test for the correct values
             assert req.app['Sessions']  # nosec
-            session = req.app['Sessions'][0]
+            session = list(req.app['Sessions'])[0]
             self.assertTrue(req.app['Creds'][session]['Token'] is not None)
             self.assertNotEqual(req.app['Creds'][session]['Avail'], "INVALID")
             self.assertEqual(req.app['Creds'][session]['active_project'], {


### PR DESCRIPTION
### Description

Hashlib + os.urandom was a suboptimal way of getting new tokens. New tokens are now made with python secrets library.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

* Move to python `secrets` module for getting tokens
* Move to python `secrets.comparedigests` to avoid timing attack vulnerabilities
* Make session validity checks time constant by moving over to set based session storage
* Flag the need to separately store newly created tokens better

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
