### PR TITLE
Disable buttons when empty containers

### DIFF
--- a/swift_browser_ui_frontend/package-lock.json
+++ b/swift_browser_ui_frontend/package-lock.json
@@ -2254,14 +2254,14 @@
       "integrity": "sha512-fzjg2gWQt+jw5fyLsD9HZNxGNQgZjLDI2s9bLWJwRucdfmncSi9neqA0TZyszGrgcJA4Qu4V5KgV0qwVSBYCaw=="
     },
     "@vue/cli-plugin-babel": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-4.3.1.tgz",
-      "integrity": "sha512-tBqu0v1l4LfWX8xuJmofpp+8xQzKddFNxdLmeVDOX/omDBQX0qaVDeMUtRxxSTazI06SKr605SnUQoa35qwbvw==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-4.4.6.tgz",
+      "integrity": "sha512-9cX9mN+4DIbcqw3rV6UBOA0t5zikIkrBLQloUzsOBOu5Xb7/UoD7inInFj7bnyHUflr5LqbdWJ+etCQcWAIIXA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
-        "@vue/babel-preset-app": "^4.3.1",
-        "@vue/cli-shared-utils": "^4.3.1",
+        "@babel/core": "^7.9.6",
+        "@vue/babel-preset-app": "^4.4.6",
+        "@vue/cli-shared-utils": "^4.4.6",
         "babel-loader": "^8.1.0",
         "cache-loader": "^4.1.0",
         "thread-loader": "^2.1.3",
@@ -2269,12 +2269,12 @@
       }
     },
     "@vue/cli-plugin-eslint": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-4.3.1.tgz",
-      "integrity": "sha512-5UEP93b8C/JQs9Rnuldsu8jMz0XO4wNXG0lL/GdChYBEheKCyXJXzan7qzEbIuvUwG3I+qlUkGsiyNokIgXejg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-4.4.6.tgz",
+      "integrity": "sha512-3a9rVpOKPQsDgAlRkhmBMHboGobivG/47BbQGE66Z8YJxrgF/AWikP3Jy67SmxtszRkyiWfw4aJFRV9r3MzffQ==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "^4.3.1",
+        "@vue/cli-shared-utils": "^4.4.6",
         "eslint-loader": "^2.2.1",
         "globby": "^9.2.0",
         "inquirer": "^7.1.0",
@@ -2296,33 +2296,33 @@
       "integrity": "sha512-Ho0YzUivn8BLPqFoFypntR8CMTEXYYHVr0GdnZW99XL+DbGw75f+tJfnrV9UFHDTfvZt7uewKiXDMlrzQ0l3Ug=="
     },
     "@vue/cli-service": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-4.3.1.tgz",
-      "integrity": "sha512-CsNGfHe+9oKZdRwJmweQ0KsMYM27ssg1eNQqRKL/t+IgDLO3Tu86uaOOCLn4ZAaU5oxxpq4aSFvz+A0YxQRSWw==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-4.4.6.tgz",
+      "integrity": "sha512-k5OFGh2NnvRymCyq9DfBiNJvECUuun3pl5KMm3557IZyA5E5csv+RHoSW3dX8HHe0zXq18g52VswP1llvR9POw==",
       "dev": true,
       "requires": {
         "@intervolga/optimize-cssnano-plugin": "^1.0.5",
         "@soda/friendly-errors-webpack-plugin": "^1.7.1",
         "@soda/get-current-script": "^1.0.0",
-        "@vue/cli-overlay": "^4.3.1",
-        "@vue/cli-plugin-router": "^4.3.1",
-        "@vue/cli-plugin-vuex": "^4.3.1",
-        "@vue/cli-shared-utils": "^4.3.1",
-        "@vue/component-compiler-utils": "^3.0.2",
+        "@vue/cli-overlay": "^4.4.6",
+        "@vue/cli-plugin-router": "^4.4.6",
+        "@vue/cli-plugin-vuex": "^4.4.6",
+        "@vue/cli-shared-utils": "^4.4.6",
+        "@vue/component-compiler-utils": "^3.1.2",
         "@vue/preload-webpack-plugin": "^1.1.0",
         "@vue/web-component-wrapper": "^1.2.0",
-        "acorn": "^7.1.0",
+        "acorn": "^7.2.0",
         "acorn-walk": "^7.1.1",
         "address": "^1.1.2",
-        "autoprefixer": "^9.7.5",
-        "browserslist": "^4.11.1",
+        "autoprefixer": "^9.8.0",
+        "browserslist": "^4.12.0",
         "cache-loader": "^4.1.0",
         "case-sensitive-paths-webpack-plugin": "^2.3.0",
         "cli-highlight": "^2.1.4",
         "clipboardy": "^2.3.0",
         "cliui": "^6.0.0",
         "copy-webpack-plugin": "^5.1.1",
-        "css-loader": "^3.4.2",
+        "css-loader": "^3.5.3",
         "cssnano": "^4.1.10",
         "debug": "^4.1.1",
         "default-gateway": "^5.0.5",
@@ -2340,18 +2340,18 @@
         "mini-css-extract-plugin": "^0.9.0",
         "minimist": "^1.2.5",
         "pnp-webpack-plugin": "^1.6.4",
-        "portfinder": "^1.0.25",
+        "portfinder": "^1.0.26",
         "postcss-loader": "^3.0.0",
         "ssri": "^7.1.0",
-        "terser-webpack-plugin": "^2.3.5",
+        "terser-webpack-plugin": "^2.3.6",
         "thread-loader": "^2.1.3",
         "url-loader": "^2.2.0",
-        "vue-loader": "^15.9.1",
+        "vue-loader": "^15.9.2",
         "vue-style-loader": "^4.1.2",
         "webpack": "^4.0.0",
-        "webpack-bundle-analyzer": "^3.6.1",
+        "webpack-bundle-analyzer": "^3.8.0",
         "webpack-chain": "^6.4.0",
-        "webpack-dev-server": "^3.10.3",
+        "webpack-dev-server": "^3.11.0",
         "webpack-merge": "^4.2.2"
       },
       "dependencies": {
@@ -3742,6 +3742,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -6721,6 +6730,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -9465,7 +9480,8 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
     },
     "pify": {
       "version": "4.0.1",
@@ -12633,6 +12649,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -12909,6 +12926,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/swift_browser_ui_frontend/package.json
+++ b/swift_browser_ui_frontend/package.json
@@ -26,9 +26,9 @@
     "vuex": "^3.5.1"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.3.1",
-    "@vue/cli-plugin-eslint": "^4.3.1",
-    "@vue/cli-service": "^4.3.1",
+    "@vue/cli-plugin-babel": "^4.4.6",
+    "@vue/cli-plugin-eslint": "^4.4.6",
+    "@vue/cli-service": "^4.4.6",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",

--- a/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
@@ -1,5 +1,20 @@
 <template>
   <b-button
+    v-if="disabled"
+    tag="a"
+    type="is-primary"
+    outlined
+    target="_blank"
+    :inverted="inverted"
+    disabled
+  >
+    <b-icon
+      icon="download"
+      size="is-small"
+    /> {{ $t('message.downloadContainer') }}
+  </b-button>
+  <b-button
+    v-else
     tag="a"
     type="is-primary"
     outlined
@@ -10,7 +25,7 @@
     <b-icon
       icon="download"
       size="is-small"
-    />{{ $t('message.downloadContainer') }}
+    /> {{ $t('message.downloadContainer') }}
   </b-button>
 </template>
 
@@ -21,6 +36,7 @@ export default {
     "container",
     "project",
     "inverted",
+    "disabled",
   ],
   data: function () {
     return {

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -154,6 +154,7 @@
               v-if="props.row.bytes < 1073741824"
               :href="props.row.url"
               target="_blank"
+              :inverted="props.row == selected ? true : false"
               :alt="$t('message.downloadAlt') + ' ' + props.row.name"
               type="is-primary"
               outlined
@@ -169,6 +170,7 @@
               v-else-if="allowLargeDownloads"
               :href="props.row.url"
               target="_blank"
+              :inverted="props.row == selected ? true : false"
               :alt="$t('message.downloadAlt') + ' ' + props.row.name"
               type="is-primary"
               outlined
@@ -185,6 +187,7 @@
               :alt="$t('message.downloadAltLarge') + ' ' + props.row.name"
               type="is-primary"
               outlined
+              :inverted="props.row === selected ? true : false"
               size="is-small"
               tag="a"
               @click="confirmDownload ()"

--- a/swift_browser_ui_frontend/src/components/ReplicateContainer.vue
+++ b/swift_browser_ui_frontend/src/components/ReplicateContainer.vue
@@ -1,5 +1,32 @@
 <template>
-  <div>
+  <div v-if="disabled">
+    <b-button
+      v-if="smallsize"
+      type="is-primary"
+      size="is-small"
+      outlined
+      disabled
+      :inverted="inverted"
+    >
+      <b-icon
+        icon="content-copy"
+        size="is-small"
+      /> {{ $t('message.copy') }}
+    </b-button>
+    <b-button
+      v-else
+      type="is-primary"
+      outlined
+      :inverted="inverted"
+      disabled
+    >
+      <b-icon
+        icon="content-copy"
+        size="is-small"
+      /> {{ $t('message.copy') }}
+    </b-button>
+  </div>
+  <div v-else>
     <b-button
       v-if="smallsize"
       type="is-primary"
@@ -17,7 +44,7 @@
       <b-icon
         icon="content-copy"
         size="is-small"
-      />{{ $t('message.copy') }}
+      /> {{ $t('message.copy') }}
     </b-button>
     <b-button
       v-else
@@ -35,7 +62,7 @@
       <b-icon
         icon="content-copy"
         size="is-small"
-      />{{ $t('message.copy') }}
+      /> {{ $t('message.copy') }}
     </b-button>
   </div>
 </template>
@@ -48,6 +75,7 @@ export default {
     "container",
     "smallsize",
     "inverted",
+    "disabled",
   ],
   computed: {
     active () {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -126,11 +126,43 @@
                 :container="props.row.name"
               />
             </p>
-            <p class="control">
+            <p
+              v-if="!props.row.bytes"
+              class="control"
+            >
               <b-button
                 v-if="selected==props.row"
                 type="is-primary"
-                icon-left="share"
+                outlined
+                size="is-small"
+                disabled
+                inverted
+              >
+                <b-icon
+                  icon="share"
+                  size="is-small"
+                /> {{ $t('message.share.share') }}
+              </b-button>
+              <b-button
+                v-else
+                type="is-primary"
+                outlined
+                size="is-small"
+                disabled
+              >
+                <b-icon
+                  icon="share"
+                  size="is-small"
+                /> {{ $t('message.share.share') }}
+              </b-button>
+            </p>
+            <p
+              v-else
+              class="control"
+            >
+              <b-button
+                v-if="selected==props.row"
+                type="is-primary"
                 outlined
                 size="is-small"
                 inverted
@@ -139,12 +171,14 @@
                   query: {container: props.row.name}
                 })"
               >
-                {{ $t('message.share.share') }}
+                <b-icon
+                  icon="share"
+                  size="is-small"
+                /> {{ $t('message.share.share') }}
               </b-button>
               <b-button
                 v-else
                 type="is-primary"
-                icon-left="share"
                 outlined
                 size="is-small"
                 @click="$router.push({
@@ -152,7 +186,10 @@
                   query: {container: props.row.name}
                 })"
               >
-                {{ $t('message.share.share') }}
+                <b-icon
+                  icon="share"
+                  size="is-small"
+                /> {{ $t('message.share.share') }}
               </b-button>
             </p>
             <p class="control">

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -118,11 +118,13 @@
                 v-if="selected==props.row"
                 class="is-small"
                 :inverted="true"
+                :disabled="!props.row.bytes ? true : false"
                 :container="props.row.name"
               />
               <ContainerDownloadLink
                 v-else
                 class="is-small"
+                :disabled="!props.row.bytes ? true : false"
                 :container="props.row.name"
               />
             </p>
@@ -198,12 +200,14 @@
                 :project="active.id"
                 :container="props.row.name"
                 :smallsize="true"
+                :disabled="!props.row.bytes ? true : false"
                 :inverted="true"
               />
               <ReplicateContainerButton
                 v-else
                 :project="active.id"
                 :container="props.row.name"
+                :disabled="!props.row.bytes ? true : false"
                 :smallsize="true"
               />
             </p>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Should not be able to download empty containers and also disable the download link created and the click event.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #91 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. Configure buttons to be disabled when container is empty (0 Bytes)
Before:
![image](https://user-images.githubusercontent.com/47524/87955378-55c42d00-cab6-11ea-9862-6c47c8053ba5.png)

Fixed:
![image](https://user-images.githubusercontent.com/47524/87955251-244b6180-cab6-11ea-971e-edf6050910ae.png)


2. fix button styling to be more uniform
3. fix issue when hovering over download button
Before:
![image](https://user-images.githubusercontent.com/47524/87955437-6d9bb100-cab6-11ea-8fee-e63d8938f188.png)
Fixed:
![image](https://user-images.githubusercontent.com/47524/87955593-a176d680-cab6-11ea-8664-1912fafc9e99.png)


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
