### PR TITLE
Bugfix/fix object refresh after upload

### DIFF
--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -51,22 +51,3 @@ export function getHumanReadableSize (val) {
   }
   return ret;
 }
-
-export function recursivePruneCache (object_cache) {
-  // Prune the object_cache until the cache is < 250000 objects in total
-  if (getNestedObjectTotal(object_cache) > 250000) {
-    delete object_cache[Object.keys(object_cache)[0]];
-    return recursivePruneCache(object_cache);
-  }
-  return object_cache;
-}
-
-function getNestedObjectTotal (nested) {
-  // Get the size of a object containing arrays, in the amount of total
-  // array elements
-  let ret = 0;
-  for (var key in nested) {
-    ret += nested[key].length;
-  }
-  return ret;
-}

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import Vuex from "vuex";
 
-import { recursivePruneCache } from "@/common/conv";
+// import { recursivePruneCache } from "@/common/conv";
 import { getBuckets } from "@/common/api";
 import { 
   getObjects,
@@ -19,8 +19,7 @@ const store = new Vuex.Store({
     multipleProjects: false,
     isLoading: false,
     isFullPage: true,
-    objectCache: {},
-    sharedObjects: undefined,
+    objectCache: [],
     containerCache: [],
     langs: [
       {ph: "In English", value: "en"},
@@ -33,15 +32,6 @@ const store = new Vuex.Store({
     isChunking: false,
     uploadProgress: undefined,
     altContainer: undefined,
-  },
-  getters: {
-    getObjectsByContainer: (state) => (container) => {
-      return (
-        state.objectCache[container] != undefined ?
-          state.objectCache[container] :
-          []
-      );
-    },
   },
   mutations: {
     updateContainers (state) {
@@ -65,9 +55,9 @@ const store = new Vuex.Store({
       let container = payload.route.params.container;
       state.isLoading = true;
       if (payload.route.name == "SharedObjects") {
+        payload.route.params.project,
+        container,
         state.client.getAccessDetails(
-          payload.route.params.project,
-          container,
           payload.route.params.owner,
         ).then(
           (ret) => {
@@ -80,7 +70,7 @@ const store = new Vuex.Store({
         ).then(
           (ret) => {
             state.isLoading = false;
-            state.sharedObjects = ret;
+            state.objectCache = ret;
           },
         ).catch(() => {
           state.isLoading = false;
@@ -91,8 +81,8 @@ const store = new Vuex.Store({
           if (ret.status != 200) {
             state.isLoading = false;
           }
-          state.objectCache = recursivePruneCache(state.objectCache);
-          state.objectCache[container] = ret;
+          // state.objectCache = recursivePruneCache(state.objectCache);
+          state.objectCache = ret;
           state.isLoading = false;
         }).catch(() => {
           state.isLoading = false;
@@ -100,7 +90,7 @@ const store = new Vuex.Store({
       }
     },
     eraseObjects (state) {
-      state.objectCache = {};
+      state.objectCache = [];
     },
     setProjects (state, newProjects) {
       // Update the project listing in store

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -36,7 +36,11 @@ const store = new Vuex.Store({
   },
   getters: {
     getObjectsByContainer: (state) => (container) => {
-      return state.objectCache[container];
+      return (
+        state.objectCache[container] != undefined ?
+          state.objectCache[container] :
+          []
+      );
     },
   },
   mutations: {

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -2,7 +2,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
 
-// import { recursivePruneCache } from "@/common/conv";
 import { getBuckets } from "@/common/api";
 import { 
   getObjects,
@@ -81,7 +80,6 @@ const store = new Vuex.Store({
           if (ret.status != 200) {
             state.isLoading = false;
           }
-          // state.objectCache = recursivePruneCache(state.objectCache);
           state.objectCache = ret;
           state.isLoading = false;
         }).catch(() => {

--- a/swift_browser_ui_frontend/src/components/FolderUpload.vue
+++ b/swift_browser_ui_frontend/src/components/FolderUpload.vue
@@ -35,15 +35,9 @@ export default {
   data: function () {
     return {
       id: "upload-".concat(Date.now().toString()),
-      containerName: undefined,
-      address: "",
-      resum: undefined,
     };
   },
   computed: {
-    active () {
-      return this.$store.state.active;
-    },
     res () {
       return this.$store.state.resumableClient;
     },

--- a/swift_browser_ui_frontend/src/components/FolderUpload.vue
+++ b/swift_browser_ui_frontend/src/components/FolderUpload.vue
@@ -11,22 +11,21 @@
         size="is-small"
       />{{ $t('message.cancelupload') }}
     </b-button>
-    <a
+    <UploadButton
       v-else
       :id="id"
-      class="button is-outlined is-primary"
-    >
-      <b-icon
-        icon="upload"
-        size="is-small"
-      />{{ $t('message.upload') }}
-    </a>
+    />
   </div>
 </template>
 
 <script>
+import UploadButton from "@/components/UploadButton";
+
 export default {
   name: "FolderUploadForm",
+  components: {
+    UploadButton,
+  },
   props: {
     dropelement: {
       default: "",
@@ -58,7 +57,6 @@ export default {
   methods: {
     registerToResumable: function () {
       // Add elements to listen
-      this.res.assignBrowse(document.getElementById(this.id));
       if(this.dropelement != "") {
         this.res.assignDrop(document.getElementById(this.dropelement));
       }

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -293,7 +293,7 @@ export default {
       return (
         this.$route.name == "SharedObjects" ?
           this.$store.state.sharedObjects :
-          this.$store.getters.getObjectcsByContainer(
+          this.$store.getters.getObjectsByContainer(
             this.$route.params.container,
           )
       );
@@ -336,7 +336,7 @@ export default {
       if (this.objects.length < 1) {
         this.$store.commit({
           type: "updateObjects",
-          route: this.route,
+          route: this.$route,
         });
       }
     },

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -290,13 +290,7 @@ export default {
       return this.$route.query.page || 1;
     },
     objects () {
-      return (
-        this.$route.name == "SharedObjects" ?
-          this.$store.state.sharedObjects :
-          this.$store.getters.getObjectsByContainer(
-            this.$route.params.container,
-          )
-      );
+      return this.$store.state.objectCache;
     },
   },
   watch: {
@@ -305,6 +299,13 @@ export default {
       this.debounceFilter();
     },
     renderFolders: function () {
+      if (this.renderFolders) {
+        this.oList = this.getFolderContents();
+      } else {
+        this.oList = this.objects;
+      }
+    },
+    objects: function () {
       if (this.renderFolders) {
         this.oList = this.getFolderContents();
       } else {
@@ -326,19 +327,17 @@ export default {
     this.debounceFilter = debounce(this.filter, 400);
   },
   beforeMount () {
-    this.fetchObjects();
+    this.updateObjects();
     this.getDirectCurrentPage();
     this.checkLargeDownloads();
   },
   methods: {
-    fetchObjects: function () {
+    updateObjects: function () {
       // Update current object listing in Vuex if length is too little
-      if (this.objects.length < 1) {
-        this.$store.commit({
-          type: "updateObjects",
-          route: this.$route,
-        });
-      }
+      this.$store.commit({
+        type: "updateObjects",
+        route: this.$route,
+      });
     },
     checkLargeDownloads: function () {
       if (document.cookie.match("ENA_DL")) {

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -256,10 +256,6 @@
 </template>
 
 <script>
-import {
-  getObjects,
-  getSharedObjects,
-} from "@/common/api";
 import { getHumanReadableSize } from "@/common/conv";
 import debounce from "lodash/debounce";
 import escapeRegExp from "lodash/escapeRegExp";
@@ -277,7 +273,6 @@ export default {
   data: function () {
     return {
       oList: [],
-      objects: [],
       selected: undefined,
       isPaginated: true,
       renderFolders: false,
@@ -294,18 +289,20 @@ export default {
     queryPage () {
       return this.$route.query.page || 1;
     },
+    objects () {
+      return (
+        this.$route.name == "SharedObjects" ?
+          this.$store.state.sharedObjects :
+          this.$store.getters.getObjectcsByContainer(
+            this.$route.params.container,
+          )
+      );
+    },
   },
   watch: {
     searchQuery: function () {
       // Run debounced search every time the search box input changes
       this.debounceFilter();
-    },
-    objects: function () {
-      if (this.renderFolders) {
-        this.oList = this.getFolderContents();
-      } else {
-        this.oList = this.objects;
-      }
     },
     renderFolders: function () {
       if (this.renderFolders) {
@@ -335,44 +332,12 @@ export default {
   },
   methods: {
     fetchObjects: function () {
-      // Get the object listing from the API if the listing hasn't yet 
-      // been cached
-      if (this.$route.name == "SharedObjects") {
-        this.$store.state.client.getAccessDetails(
-          this.$route.params.project,
-          this.$route.params.container,
-          this.$route.params.owner,
-        ).then(
-          (ret) => {
-            return getSharedObjects(
-              this.$route.params.owner,
-              this.$route.params.container,
-              ret.address,
-            );
-          },
-        ).then(
-          (ret) => {
-            this.objects = ret;
-          },
-        );
-      }
-      else {
-        let container = this.$route.params.container;
-        if(this.$store.state.objectCache[container] == undefined) {
-          this.$store.commit("setLoading", true);
-          getObjects(container).then((ret) => {
-            if (ret.status != 200) {
-              this.$store.commit("setLoading", false);
-            }
-            this.$store.commit("updateObjects", [container, ret]);
-            this.objects = ret;
-            this.$store.commit("setLoading", false);
-          }).catch(() => {
-            this.$store.commit("setLoading", false);
-          });
-        } else {
-          this.objects = this.$store.state.objectCache[container];
-        }
+      // Update current object listing in Vuex if length is too little
+      if (this.objects.length < 1) {
+        this.$store.commit({
+          type: "updateObjects",
+          route: this.route,
+        });
       }
     },
     checkLargeDownloads: function () {

--- a/swift_browser_ui_frontend/src/components/UploadButton.vue
+++ b/swift_browser_ui_frontend/src/components/UploadButton.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <a
+      :id="id"
+      class="button is-outlined is-primary"
+    >
+      <b-icon
+        icon="upload"
+        size="is-small"
+      />{{ $t('message.upload') }}
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "UploadButton",
+  props: ["id"],
+  computed: {
+    res () {
+      return this.$store.state.resumableClient;
+    },
+  },
+  mounted () {
+    this.registerToResumable();
+  },
+  activated () {
+    this.registerToResumable();
+  },
+  methods: {
+    registerToResumable: function () {
+      this.res.assignBrowse(document.getElementById(this.$props.id));
+    },
+  },
+};
+</script>

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -201,6 +201,12 @@ new Vue({
       this.endUpload();
       this.stopChunking();
       this.$store.commit("eraseProgress");
+      if (this.$route.params.container != undefined) {
+        this.$store.commit({
+          type: "updateObjects",
+          route: this.$route,
+        });
+      }
     },
     onCancel: function () {
       this.onComplete();

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -183,7 +183,6 @@ new Vue({
         if (
           newParam[0].match("resumableRelativePath")
           && this.$route.query.prefix != undefined
-          && !newParam[1].match("/")  // only pseudofolderize incomplete paths
         ) {
           retUrl.searchParams.append(
             newParam[0],

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -152,8 +152,14 @@ new Vue({
     fileSuccessToast: function (file) {
       this.$buefy.toast.open({
         message: this.$t("message.upfinish").concat(file.fileName),
-        type: "is-success",  
+        type: "is-success",
       });
+      if (this.$route.params.container != undefined) {
+        this.$store.commit({
+          type: "updateObjects",
+          route: this.$route,
+        });
+      }
     },
     fileFailureToast: function (file) {
       this.$buefy.toast.open({
@@ -201,12 +207,6 @@ new Vue({
       this.endUpload();
       this.stopChunking();
       this.$store.commit("eraseProgress");
-      if (this.$route.params.container != undefined) {
-        this.$store.commit({
-          type: "updateObjects",
-          route: this.$route,
-        });
-      }
     },
     onCancel: function () {
       this.onComplete();

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -178,7 +178,20 @@ new Vue({
       );
       for (const param of params) {
         let newParam = param.split("=");
-        retUrl.searchParams.append(newParam[0], newParam[1]);
+        // check if we should move the file under a pseudofolder
+        // using the current prefix defined in route for the url
+        if (
+          newParam[0].match("resumableRelativePath")
+          && this.$route.query.prefix != undefined
+          && !newParam[1].match("/")  // only pseudofolderize incomplete paths
+        ) {
+          retUrl.searchParams.append(
+            newParam[0],
+            this.$route.query.prefix + newParam[1],
+          );
+        } else {
+          retUrl.searchParams.append(newParam[0], newParam[1]);
+        }
       }
       return retUrl.toString();
     },


### PR DESCRIPTION
### Description

Fixes issue #110 – the objects in a container are now dynamically refreshed whenever an object upload completes. The refreshes are done upon completion of each uploaded file. File refreshes work also inside pseudofolders.
Additionally the PR fixes a newfound issue in the upload button, which did not re-register to the UI correctly after being replaced with upload cancellation, and implements uploads into pseudofolders from the button, and from drag-n-drop.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes #110 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Move object listing to Vuex to make allow updating objects outside `ObjectTable` component
* Remove caching object listings since checking for new content requires a full `GET` with current backend implementation, making caching somewhat unnecessary
* Move upload button from `FolderUploadForm` into its own component, to enable re-registration to `Resumable` object upon reactivation in the UI when an upload completes
* Rewrite `getUploadUrl` in `main.js` to enable uploading single files into pseudofolders (+ folders with drag-n-drop)
* Removed some unnecessary stuff

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
