### PR TITLE
Feature/direct share create

### DIFF
--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -639,7 +639,7 @@ async def get_access_control_metadata(
 
     # Get a list of containers
     containers: typing.List[dict] = []
-    [_unpack(i, containers, request) for i in serv]
+    [_unpack(i, containers, request) for i in serv.list()]
 
     host = sess.get_endpoint(service_type="object-store")
 

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -12,6 +12,7 @@ import DirectRequest from "@/views/DirectRequest";
 import ReplicationView from "@/views/Replicate";
 import Tokens from "@/views/Tokens";
 import CreateContainer from "@/views/AddContainer";
+import DirectShare from "@/views/DirectShare";
 
 Vue.use(Router);
 
@@ -47,6 +48,11 @@ export default new Router({
       path: "/browse/sharing/requestdirect",
       name: "DirectRequest",
       component: DirectRequest,
+    },
+    {
+      path: "/browse/sharing/sharedirect",
+      name: "DirectShare",
+      component: DirectShare,
     },
     {
       path: "/browse/shared/:project/:owner/:container",

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -54,9 +54,9 @@ const store = new Vuex.Store({
       let container = payload.route.params.container;
       state.isLoading = true;
       if (payload.route.name == "SharedObjects") {
-        payload.route.params.project,
-        container,
         state.client.getAccessDetails(
+          payload.route.params.project,
+          container,
           payload.route.params.owner,
         ).then(
           (ret) => {

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -373,7 +373,6 @@ export default {
     this.debounceFilter = debounce(this.filter, 400);
   },
   beforeMount () {
-    // this.updateObjects();
     this.getDirectCurrentPage();
     this.checkLargeDownloads();
   },

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -373,9 +373,12 @@ export default {
     this.debounceFilter = debounce(this.filter, 400);
   },
   beforeMount () {
-    this.updateObjects();
+    // this.updateObjects();
     this.getDirectCurrentPage();
     this.checkLargeDownloads();
+  },
+  mounted () {
+    this.updateObjects();
   },
   methods: {
     updateObjects: function () {

--- a/swift_browser_ui_frontend/src/views/DirectRequest.vue
+++ b/swift_browser_ui_frontend/src/views/DirectRequest.vue
@@ -124,7 +124,6 @@ export default {
             type: "is-danger",
           });
         }
-
         else {
           this.requestShare();
         }

--- a/swift_browser_ui_frontend/src/views/DirectShare.vue
+++ b/swift_browser_ui_frontend/src/views/DirectShare.vue
@@ -8,7 +8,6 @@
     </h3>
     <b-field
       v-if="projects.length > 1"
-      horizontal
       :label="$t('message.share.from_me')"
     >
       <b-select
@@ -24,7 +23,9 @@
         </option>
       </b-select>
     </b-field>
-    <b-field grouped>
+    <b-field
+      grouped
+    >
       <b-switch
         v-model="read"
       >
@@ -37,7 +38,6 @@
       </b-switch>
     </b-field>
     <b-field
-      horizontal
       :label="$t('message.share.container')"
     >
       <b-input 
@@ -47,7 +47,6 @@
         aria-required="true"
       />
     </b-field>
-
     <b-field
       :label="$t('message.share.field_label')"
     >
@@ -57,9 +56,7 @@
       />
     </b-field>
 
-    <b-field
-      horizontal
-    >
+    <b-field>
       <p class="control">
         <button
           class="button is-primary"
@@ -107,8 +104,15 @@ export default {
   },
   methods: {
     createAndShare: function () {
-      this.asyncCreateAndShare().then(() => {
-        this.router.go("/");
+      this.asyncCreateAndShare().then((ret) => {
+        if (ret) {
+          this.router.go({
+            name: "SharedFrom",
+            params: {
+              project: this.active,
+            },
+          });
+        }
       });
     },
     asyncCreateAndShare: async function () {
@@ -144,6 +148,7 @@ export default {
         rights,
         await getSharedContainerAddress(),
       );
+      return true;
     },
     setActive: function (wait) {
       try {

--- a/swift_browser_ui_frontend/src/views/DirectShare.vue
+++ b/swift_browser_ui_frontend/src/views/DirectShare.vue
@@ -101,9 +101,9 @@ export default {
     },
   },
   beforeMount () {
-    this.setActive(50);
-    this.checkMultiProject(50);
-    this.setParams(50);
+    this.setActive(100);
+    this.setParams(100);
+    delay(this.checkMultiProject, 100, [200]);
   },
   methods: {
     createAndShare: function () {
@@ -113,10 +113,10 @@ export default {
     },
     asyncCreateAndShare: async function () {
       let rights = [];
-      if (this.$read) {
+      if (this.read) {
         rights.push("r");
       }
-      if (this.$write) {
+      if (this.write) {
         rights.push("w");
       }
       if (rights.length < 1) {
@@ -164,15 +164,14 @@ export default {
     },
     checkMultiProject: function (wait) {
       try {
-        if (this.projects.length > 1) {
+        if (this.projects.length == 1 && this.projects != undefined) {
+          this.createAndShare();
+        } else {
           this.$buefy.notification.open({
             indefinite: true,
             message: this.$t("message.request.multi_project"),
             type: "is-danger",
           });
-        }
-        else {
-          this.createAndShare();
         }
       } catch (ReferenceError) {
         delay(this.checkMultiProject, wait, [wait * 2]);

--- a/swift_browser_ui_frontend/src/views/DirectShare.vue
+++ b/swift_browser_ui_frontend/src/views/DirectShare.vue
@@ -1,0 +1,194 @@
+<template>
+  <div
+    id="sharingview"
+    class="contents"
+  >
+    <h3 class="title is-3 sharinghead">
+      {{ $t('message.share.share') }}
+    </h3>
+    <b-field
+      v-if="projects.length > 1"
+      horizontal
+      :label="$t('message.share.from_me')"
+    >
+      <b-select
+        v-model="project"
+        :placeholder="active.name"
+      >
+        <option
+          v-for="item in projects"
+          :key="item.id"
+          :value="item.id"
+        >
+          {{ item.name }}
+        </option>
+      </b-select>
+    </b-field>
+    <b-field grouped>
+      <b-switch
+        v-model="read"
+      >
+        {{ $t('message.share.read_perm') }}
+      </b-switch>
+      <b-switch
+        v-model="write"
+      >
+        {{ $t('message.share.write_perm') }}
+      </b-switch>
+    </b-field>
+    <b-field
+      horizontal
+      :label="$t('message.share.container')"
+    >
+      <b-input 
+        v-model="container"
+        name="container"
+        expanded
+        aria-required="true"
+      />
+    </b-field>
+
+    <b-field
+      :label="$t('message.share.field_label')"
+    >
+      <b-taginput
+        v-model="tags"
+        :placeholder="$t('message.share.field_placeholder')"
+      />
+    </b-field>
+
+    <b-field
+      horizontal
+    >
+      <p class="control">
+        <button
+          class="button is-primary"
+          @click="createAndShare ()"
+        >
+          {{ $t('message.share.share_cont') }}
+        </button>
+      </p>
+    </b-field>
+  </div>
+</template>
+
+<script>
+import delay from "lodash/delay";
+import {
+  changeProjectApi,
+  addAccessControlMeta,
+  swiftCreateContainer,
+  getSharedContainerAddress,
+} from "@/common/api.js";
+
+export default {
+  name: "DirectShare",
+  data () {
+    return {
+      container: "",
+      tags: [],
+      project: "",
+      read: true,
+      write: true,
+    };
+  },
+  computed: {
+    projects () {
+      return this.$store.state.projects;
+    },
+    active () {
+      return this.$store.state.active;
+    },
+  },
+  beforeMount () {
+    this.setActive(50);
+    this.checkMultiProject(50);
+    this.setParams(50);
+  },
+  methods: {
+    createAndShare: function () {
+      this.asyncCreateAndShare().then(() => {
+        this.router.go("/");
+      });
+    },
+    asyncCreateAndShare: async function () {
+      let rights = [];
+      if (this.$read) {
+        rights.push("r");
+      }
+      if (this.$write) {
+        rights.push("w");
+      }
+      if (rights.length < 1) {
+        this.$buefy.toast.open({
+          duration: 5000,
+          message: this.$t("message.share.fail_noperm"),
+          type: "is-danger",
+        });
+      }
+      // ensure correct project for creation
+      if (this.project != this.$store.state.active) {
+        await changeProjectApi(this.project);
+      }
+      // create the container
+      await swiftCreateContainer(this.container);
+      await addAccessControlMeta(
+        this.container,
+        rights,
+        this.tags,
+      );
+      await this.$store.state.client.shareNewAccess(
+        this.project,
+        this.container,
+        this.tags,
+        rights,
+        await getSharedContainerAddress(),
+      );
+    },
+    setActive: function (wait) {
+      try {
+        this.project = this.active.id;
+      } catch(ReferenceError) {
+        delay(this.setActive, wait, [wait * 2]);
+      }
+    },
+    setParams: function (wait) {
+      try {
+        this.container = this.$route.query.container;
+        for (let uuid of this.$route.query.projects.split(",")) {
+          this.tags.push(uuid);
+        }
+      } catch (ReferenceError) {
+        delay(this.setParams, wait, [wait * 2]);
+      }
+    },
+    checkMultiProject: function (wait) {
+      try {
+        if (this.projects.length > 1) {
+          this.$buefy.notification.open({
+            indefinite: true,
+            message: this.$t("message.request.multi_project"),
+            type: "is-danger",
+          });
+        }
+        else {
+          this.createAndShare();
+        }
+      } catch (ReferenceError) {
+        delay(this.checkMultiProject, wait, [wait * 2]);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+  #sharingview {
+    width: auto;
+    margin-left: 5%;
+    margin-right: 5%;
+  }
+  .sharinghead {
+    margin: 1% 1% 1% 0;
+  }
+</style>

--- a/swift_browser_ui_frontend/src/views/DirectShare.vue
+++ b/swift_browser_ui_frontend/src/views/DirectShare.vue
@@ -106,7 +106,7 @@ export default {
     createAndShare: function () {
       this.asyncCreateAndShare().then((ret) => {
         if (ret) {
-          this.router.go({
+          this.$router.go({
             name: "SharedFrom",
             params: {
               project: this.active,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This branch includes functionality for a new type of share link, which can be used for creating a new container and grant access to it straight away. This way, if another user wants to upload data to another project, the other project can click on said link, thus making it possible for the other project to directly upload things into said container. This simplifies the data sharing workflow considerably.

The branch also contains some bugfixes in the sharing functionality.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes #195

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Add possibility to directly request another project to create and share a container
* Fix issues with opening shared containers
* Fix issues when unpacking container acl metadata, thus fixing ACL synchronization to the sharing database

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
