### PR TITLE
change upload chunk size

### DIFF
--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -380,9 +380,7 @@ async def swift_upload_object_chunk(
     resp = aiohttp.web.Response(status=307)
     resp.headers["Location"] = f"{setd['upload_external_endpoint']}{path}"
 
-    request.app["Log"].info(
-        f"redirecting {session} to {resp.headers['Location']}"
-    )
+    request.app["Log"].info(f"redirecting {session} to {resp.headers['Location']}")
 
     return resp
 

--- a/swift_browser_ui/api.py
+++ b/swift_browser_ui/api.py
@@ -380,6 +380,10 @@ async def swift_upload_object_chunk(
     resp = aiohttp.web.Response(status=307)
     resp.headers["Location"] = f"{setd['upload_external_endpoint']}{path}"
 
+    request.app["Log"].info(
+        f"redirecting {session} to {resp.headers['Location']}"
+    )
+
     return resp
 
 

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -234,7 +234,7 @@ new Vue({
       let res = new Resumable({
         target: this.getUploadUrl,
         testTarget: this.getUploadUrl,
-        chunkSize: 268435456,
+        chunkSize: 5242880,
         forceChunkSize: true,
         simultaneousUploads: 1,
       });


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Reduce upload chunk size to 5MiB. This fixes the issue with upload timeouts in `CSC Rahti` environment by reducing upload size enough for uploads going through with a 4 mbps connection, but doesn't increase overhead too much.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes issue #224 – package redirection

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

Breaks compatibility with upload-runner versions `<=0.1.8` – requires version that works properly with smaller chunks for segmented uploads. Thus needs `swift_upload_runner` of at least `v0.2.0`

### Changes Made

<!-- List changes made. -->
* Reduce `resumable.js` upload chunk size to 5MiB.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
