### PR TITLE
Feature/support credential login

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = f"{current_year}, CSC Developers"
 author = "CSC Developers"
 
 # The full version, including alpha/beta/rc tags
-version = release = "1.1.0b2"
+version = release = "1.1.0b3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/swift_browser_ui/__init__.py
+++ b/swift_browser_ui/__init__.py
@@ -7,6 +7,6 @@ with the object storage.
 
 
 __name__ = "swift_browser_ui"
-__version__ = "1.1.0b2"
+__version__ = "1.1.0b3"
 __author__ = "CSC Developers"
 __license__ = "MIT License"

--- a/swift_browser_ui/_convenience.py
+++ b/swift_browser_ui/_convenience.py
@@ -338,7 +338,7 @@ def os_get_token_from_credentials(
         setd["auth_endpoint_url"],
         username=username,
         password=password,
-        user_domain_name="Default",
+        user_domain_name=setd["os_user_domain"],
         unscoped=True,
     )
 

--- a/swift_browser_ui/_convenience.py
+++ b/swift_browser_ui/_convenience.py
@@ -335,12 +335,19 @@ def os_get_token_from_credentials(
 ) -> str:
     """Get an unscoped token with provided credentials."""
     os_auth = v3.Password(
-        auth_url=setd["auth_endpoint_url"],
+        setd["auth_endpoint_url"],
         username=username,
         password=password,
+        user_domain_name="Default",
+        unscoped=True,
     )
 
-    return os_auth.get_token()
+    os_session = keystoneauth1.session.Session(
+        auth=os_auth,
+        verify=True,
+    )
+
+    return os_session.get_token()
 
 
 def initiate_os_service(

--- a/swift_browser_ui/_convenience.py
+++ b/swift_browser_ui/_convenience.py
@@ -329,6 +329,20 @@ def initiate_os_session(unscoped: str, project: str) -> keystoneauth1.session.Se
     )
 
 
+def os_get_token_from_credentials(
+    username: str,
+    password: str,
+) -> str:
+    """Get an unscoped token with provided credentials."""
+    os_auth = v3.Password(
+        auth_url=setd["auth_endpoint_url"],
+        username=username,
+        password=password,
+    )
+
+    return os_auth.get_token()
+
+
 def initiate_os_service(
     os_session: keystoneauth1.session.Session, url: str = None
 ) -> swiftclient.service.SwiftService:

--- a/swift_browser_ui/front.py
+++ b/swift_browser_ui/front.py
@@ -47,7 +47,7 @@ async def index(
 
 async def loginpassword(
     request: typing.Optional[aiohttp.web.Request],
-) -> aiohttp.Union[aiohttp.web.Response, aiohttp.web.FileResponse]:
+) -> typing.Union[aiohttp.web.Response, aiohttp.web.FileResponse]:
     """Serve the username and password login page."""
     try:
         if request is not None:

--- a/swift_browser_ui/front.py
+++ b/swift_browser_ui/front.py
@@ -3,6 +3,7 @@
 import typing
 
 import aiohttp.web
+from aiohttp.web_routedef import head
 
 from cryptography.fernet import InvalidToken
 
@@ -42,3 +43,25 @@ async def index(
             raise AttributeError
     except (AttributeError, InvalidToken, KeyError, aiohttp.web.HTTPUnauthorized):
         return aiohttp.web.FileResponse(str(setd["static_directory"]) + "/index.html")
+
+
+async def loginpassword(
+    request: typing.Optional[aiohttp.web.Request],
+) -> aiohttp.Union[aiohttp.web.Response, aiohttp.web.FileResponse]:
+    """Serve the username and password login page."""
+    try:
+        if request is not None:
+            session_check(request)
+            request.app["Log"].info("Redirecting an existing session to app")
+            return aiohttp.web.Response(
+                status=303,
+                headers={
+                    "Location": "/browse",
+                },
+            )
+        else:
+            raise AttributeError
+    except (AttributeError, InvalidToken, KeyError, aiohttp.web.HTTPUnauthorized):
+        return aiohttp.web.FileResponse(
+            str(setd["static_directory"]) + "/loginpassword.html"
+        )

--- a/swift_browser_ui/front.py
+++ b/swift_browser_ui/front.py
@@ -3,7 +3,6 @@
 import typing
 
 import aiohttp.web
-from aiohttp.web_routedef import head
 
 from cryptography.fernet import InvalidToken
 

--- a/swift_browser_ui/login.py
+++ b/swift_browser_ui/login.py
@@ -124,6 +124,10 @@ async def credentials_login_end(
             username,
             password,
         )
+    except keystoneauth1.exceptions.http.BadRequest:
+        raise aiohttp.web.HTTPBadRequest(
+            reason="No username or password provided."
+        )
     except keystoneauth1.exceptions.http.Unauthorized:
         raise aiohttp.web.HTTPUnauthorized(
             reason="Wrong username or password, or no access to the service."

--- a/swift_browser_ui/login.py
+++ b/swift_browser_ui/login.py
@@ -5,7 +5,6 @@ import time
 import hashlib
 import json
 import re
-import typing_extensions
 
 # aiohttp
 import aiohttp.web
@@ -14,8 +13,6 @@ from multidict import MultiDictProxy
 
 import typing
 import urllib.error
-
-from six import assertRaisesRegex
 
 from ._convenience import (
     disable_cache,

--- a/swift_browser_ui/login.py
+++ b/swift_browser_ui/login.py
@@ -125,9 +125,7 @@ async def credentials_login_end(
             password,
         )
     except keystoneauth1.exceptions.http.BadRequest:
-        raise aiohttp.web.HTTPBadRequest(
-            reason="No username or password provided."
-        )
+        raise aiohttp.web.HTTPBadRequest(reason="No username or password provided.")
     except keystoneauth1.exceptions.http.Unauthorized:
         raise aiohttp.web.HTTPUnauthorized(
             reason="Wrong username or password, or no access to the service."

--- a/swift_browser_ui/login.py
+++ b/swift_browser_ui/login.py
@@ -92,9 +92,9 @@ def test_token(
             f"from address {request.remote} :: {time.ctime()}"
         )
     if unscoped is None:
-        raise aiohttp.web.HTTPClientError(reason="Token missing from query")
+        raise aiohttp.web.HTTPBadRequest(reason="Token missing from query")
     if not (re.match("[a-f0-9]{32}", unscoped) and len(unscoped) == 32):
-        raise aiohttp.web.HTTPClientError(reason="Token is malformed")
+        raise aiohttp.web.HTTPBadRequest(reason="Token is malformed")
 
     log.info("Got OS token in login return")
 
@@ -114,7 +114,7 @@ async def credentials_login_end(
         username = str(form["username"])
         password = str(form["password"])
     except KeyError:
-        raise aiohttp.web.HTTPClientError(reason="Username or password not provided")
+        raise aiohttp.web.HTTPBadRequest(reason="Username or password not provided")
 
     log.debug(f"username: {username}, password: {password}")
 

--- a/swift_browser_ui/middlewares.py
+++ b/swift_browser_ui/middlewares.py
@@ -32,6 +32,8 @@ async def error_middleware(request: web.Request, handler: AiohttpHandler) -> web
     """Return the correct HTTP Error page."""
     try:
         response = await handler(request)
+        if response.status == 400:
+            return return_error_response(400)
         if response.status == 401:
             return return_error_response(401)
         if response.status == 403:
@@ -40,6 +42,8 @@ async def error_middleware(request: web.Request, handler: AiohttpHandler) -> web
             return return_error_response(404)
         return response
     except web.HTTPException as ex:
+        if ex.status == 400:
+            return return_error_response(400)
         if ex.status == 401:
             return return_error_response(401)
         if ex.status == 403:

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -13,7 +13,7 @@ import uvloop
 import cryptography.fernet
 import aiohttp.web
 
-from .front import index, browse
+from .front import index, browse, loginpassword
 from .login import (
     handle_login,
     handle_logout,
@@ -112,6 +112,7 @@ async def servinit() -> aiohttp.web.Application:
     app.add_routes(
         [
             aiohttp.web.get("/", index),
+            aiohttp.web.get("/loginpassword", loginpassword),
             aiohttp.web.get("/browse", browse),
             # Route all URLs prefixed by /browse to the browser page, as this is
             # an spa

--- a/swift_browser_ui/server.py
+++ b/swift_browser_ui/server.py
@@ -19,6 +19,7 @@ from .login import (
     handle_logout,
     sso_query_begin,
     sso_query_end,
+    credentials_login_end,
     token_rescope,
 )
 from .api import (
@@ -126,6 +127,7 @@ async def servinit() -> aiohttp.web.Application:
             aiohttp.web.get("/login/front", sso_query_begin),
             aiohttp.web.post("/login/return", sso_query_end),
             aiohttp.web.post("/login/websso", sso_query_end),
+            aiohttp.web.post("/login/credentials", credentials_login_end),
             aiohttp.web.get("/login/rescope", token_rescope),
         ]
     )

--- a/swift_browser_ui/settings.py
+++ b/swift_browser_ui/settings.py
@@ -69,6 +69,7 @@ setd: Dict[str, Union[str, int, None]] = {
     "sharing_request_token": environ.get("SWIFT_UI_SHARING_REQUEST_TOKEN", None),
     "has_trust": environ.get("BROWSER_START_HAS_TRUST", False),
     "set_origin_address": environ.get("BROWSER_START_SET_ORIGIN_ADDRESS", None),
+    "os_user_domain": environ.get("OS_USER_DOMAIN_NAME", "Default"),
     "logfile": None,
     "port": 8080,
     "verbose": False,

--- a/swift_browser_ui_frontend/config/sd_overrides.js
+++ b/swift_browser_ui_frontend/config/sd_overrides.js
@@ -3,7 +3,6 @@ let lang_overrides = {
   en: {
     message: {
       index: {
-        placeholder: "",
         loginmethods: [
           {
             msg: "Log In using Haka",
@@ -46,7 +45,6 @@ let lang_overrides = {
   },
   fi: {
     message: {
-      placeholder: "",
       index: {
         loginmethods: [
           {

--- a/swift_browser_ui_frontend/config/sd_overrides.js
+++ b/swift_browser_ui_frontend/config/sd_overrides.js
@@ -2,6 +2,18 @@
 let lang_overrides = {
   en: {
     message: {
+      index: {
+        loginmethods: [
+          {
+            msg: "Log In using Haka",
+            href: "/login",
+          },
+          {
+            msg: "Log in with CSC Login",
+            href: "/loginpassword",
+          },
+        ],
+      },
       program_name: "SD Connect",
       program_description: "SD Connect provides a simple-to-use web user " +
         "interface, along with a command line interface, for storing " +
@@ -33,6 +45,18 @@ let lang_overrides = {
   },
   fi: {
     message: {
+      index: {
+        loginmethods: [
+          {
+            msg: "Kirjaudu Haka:lla",
+            href: "/login",
+          },
+          {
+            msg: "Kirjaudu CSC käyttäjällä",
+            href: "/loginpassword",
+          },
+        ],
+      },
       program_name: "SD Connect",
       program_description: "SD Connect tarjoaa yksinkertaisen " +
         "web-käyttöliittymän ja komentorivikäyttöliittymän sensitiivisen " +

--- a/swift_browser_ui_frontend/config/sd_overrides.js
+++ b/swift_browser_ui_frontend/config/sd_overrides.js
@@ -3,6 +3,7 @@ let lang_overrides = {
   en: {
     message: {
       index: {
+        placeholder: "",
         loginmethods: [
           {
             msg: "Log In using Haka",
@@ -45,6 +46,7 @@ let lang_overrides = {
   },
   fi: {
     message: {
+      placeholder: "",
       index: {
         loginmethods: [
           {

--- a/swift_browser_ui_frontend/config/sd_overrides.js
+++ b/swift_browser_ui_frontend/config/sd_overrides.js
@@ -3,6 +3,7 @@ let lang_overrides = {
   en: {
     message: {
       index: {
+        formName: "CSC Account",
         loginmethods: [
           {
             msg: "Log In using Haka",
@@ -45,6 +46,7 @@ let lang_overrides = {
   },
   fi: {
     message: {
+      formName: "CSC Käyttäjä",
       index: {
         loginmethods: [
           {

--- a/swift_browser_ui_frontend/package.json
+++ b/swift_browser_ui_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift_browser_ui_frontend_npm",
-  "version": "1.1.0b2",
+  "version": "1.1.0b3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -6,6 +6,8 @@ let default_translations = {
   en: {
     message: {
       index: {
+        formName: "Openstack Account",
+        logIn: "Log In",
         loginmethods: [
           {
             msg: "Log In with SSO",
@@ -223,6 +225,8 @@ let default_translations = {
   fi: {
     message: {
       index: {
+        formName: "Openstack Käyttäjä",
+        logIn: "Kirjaudu sisään",
         loginmethods: [
           {
             msg: "Kirjaudu SSO:ta käyttäen",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -17,6 +17,10 @@ let default_translations = {
       },
       error: {
         frontPage: "To the Front Page",
+        BadRequest: "400 - Bad Request",
+        BadRequest_text: "Something was wrong with the request. This can " +
+                         "be for example due to missing password and/or " +
+                         "username.",
         UIdown: "503 - Service Unavailable",
         UIdown_text: "Allas User Interface is currently Unavailable",
         Unauthorized: "401 – Not logged in",
@@ -236,6 +240,9 @@ let default_translations = {
       },
       error: {
         frontPage: "Etusivulle",
+        BadRequest: "400 - Virheellinen pyyntö",
+        BadRequest_text: "Virhe sivupyynnössä. Tämä voi johtua esimerkiksi " +
+                         "puuttuvasta salasanasta ja/tai käyttäjänimestä ",
         UIdown: "503 - Palvelu ei ole käytettävissä",
         UIdown_text: "Allas-käyttöliittymä on tilapäisesti poissa käytöstä",
         Unauthorized: "401 – Kirjaudu sisään",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -441,7 +441,12 @@ function nestedJoin (dst, src) {
   let to_assign = [];
   for (let [key, value] of Object.entries(src)) {
     if (typeof(value) == "object") {
-      to_assign.push([key, nestedJoin(dst[key], src[key])]);
+      if (key in dst) {
+        to_assign.push([key, nestedJoin(dst[key], src[key])]);
+      }
+      else {
+        to_assign.push([key, src[key]]);
+      }
     } else {
       to_assign.push([key, value]);
     }

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -6,7 +6,12 @@ let default_translations = {
   en: {
     message: {
       index: {
-        logIn: "Log In",
+        loginmethods: [
+          {
+            msg: "Log In with SSO",
+            href: "/login",
+          },
+        ],
       },
       error: {
         frontPage: "To the Front Page",
@@ -218,7 +223,12 @@ let default_translations = {
   fi: {
     message: {
       index: {
-        logIn: "Kirjaudu sisään",
+        loginmethods: [
+          {
+            msg: "Kirjaudu SSO:ta käyttäen",
+            href: "/login",
+          },
+        ],
       },
       error: {
         frontPage: "Etusivulle",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -6,6 +6,7 @@ let default_translations = {
   en: {
     message: {
       index: {
+        placeholder: "",
         loginmethods: [
           {
             msg: "Log In with SSO",
@@ -223,6 +224,7 @@ let default_translations = {
   fi: {
     message: {
       index: {
+        placeholder: "",
         loginmethods: [
           {
             msg: "Kirjaudu SSO:ta käyttäen",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -14,7 +14,8 @@ let default_translations = {
         UIdown_text: "Allas User Interface is currently Unavailable",
         Unauthorized: "401 – Not logged in",
         Unauthorized_text: "The action requested requires logging " +
-                           "in. Use the button below to Log in.",
+                           "in, or the log in credentials were incorrect. " +
+                           "Use the button below to Log in.",
         Notfound: "404 – Could not find the page that was requested.",
         Notfound_text: "The front page, however, can be found – in the link " +
                        "below.",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -6,7 +6,6 @@ let default_translations = {
   en: {
     message: {
       index: {
-        placeholder: "",
         loginmethods: [
           {
             msg: "Log In with SSO",
@@ -224,7 +223,6 @@ let default_translations = {
   fi: {
     message: {
       index: {
-        placeholder: "",
         loginmethods: [
           {
             msg: "Kirjaudu SSO:ta käyttäen",

--- a/swift_browser_ui_frontend/src/entries/badrequest.js
+++ b/swift_browser_ui_frontend/src/entries/badrequest.js
@@ -20,13 +20,13 @@ const i18n = new VueI18n({
 });
 
 new Vue({
-  name: "Forbidden",
+  name: "BadRequest",
   i18n,
   data: {
     notindex: true,
-    badrequest: false,
+    badrequest: true,
     unauth: false,
-    forbid: true,
+    forbid: false,
     notfound: false,
     uidown: false,
     langs: [{ph: "In English", value: "en"}, {ph: "Suomeksi", value: "fi"}],

--- a/swift_browser_ui_frontend/src/entries/index.js
+++ b/swift_browser_ui_frontend/src/entries/index.js
@@ -24,6 +24,7 @@ new Vue({
   i18n,
   data: {
     notindex: false,
+    badrequest: false,
     uidown: false,
     unauth: false,
     forbid: false,

--- a/swift_browser_ui_frontend/src/entries/login.js
+++ b/swift_browser_ui_frontend/src/entries/login.js
@@ -7,6 +7,7 @@ import "@/css/prod.scss";
 new Vue ({
   data: {
     formname: "Token id:",
+    loginformname: "Openstack account:",
   },
   created() {
     document.title = this.$t("message.program_name");

--- a/swift_browser_ui_frontend/src/entries/loginpassword.js
+++ b/swift_browser_ui_frontend/src/entries/loginpassword.js
@@ -1,0 +1,42 @@
+import Vue from "vue";
+import App from "@/pages/LoginPassword.vue";
+import Buefy from "buefy";
+import VueI18n from "vue-i18n";
+
+import getLangCookie from "@/common/conv";
+import translations from "@/common/lang";
+
+// Import project css
+import "@/css/prod.scss";
+
+Vue.config.productiontip = true;
+
+Vue.use(Buefy);
+Vue.use(VueI18n);
+
+const i18n = new VueI18n({
+  locale: getLangCookie(),
+  messages: translations,
+});
+
+new Vue({
+  name: "LoginPassword",
+  i18n,
+  data: {
+    langs: [{ph: "In English", value: "en"}, {ph: "Suomeksi", value: "fi"}],
+  },
+  created() {
+    document.title = this.$t("message.program_name");
+  },
+  methods: {
+    setCookieLang: function() {
+      const expiryDate = new Date();
+      expiryDate.setMonth(expiryDate.getMonth() + 1);
+      document.cookie = "OBJ_UI_LANG=" +
+                        i18n.locale +
+                        "; path=/; expires="
+                        + expiryDate.toUTCString();
+    },
+  },
+  ...App,
+}).$mount("#app");

--- a/swift_browser_ui_frontend/src/entries/notfound.js
+++ b/swift_browser_ui_frontend/src/entries/notfound.js
@@ -24,6 +24,7 @@ new Vue({
   i18n,
   data: {
     notindex: true,
+    badrequest: false,
     unauth: false,
     forbid: false,
     notfound: true,

--- a/swift_browser_ui_frontend/src/entries/uidown.js
+++ b/swift_browser_ui_frontend/src/entries/uidown.js
@@ -24,6 +24,7 @@ new Vue({
   i18n,
   data: {
     notindex: true,
+    badrequest: false,
     unauth: false,
     forbid: false,
     notfound: false,

--- a/swift_browser_ui_frontend/src/entries/unauth.js
+++ b/swift_browser_ui_frontend/src/entries/unauth.js
@@ -24,6 +24,7 @@ new Vue({
   i18n,
   data: {
     notindex: true,
+    badrequest: false,
     unauth: true,
     forbid: false,
     notfound: false,

--- a/swift_browser_ui_frontend/src/pages/Index.vue
+++ b/swift_browser_ui_frontend/src/pages/Index.vue
@@ -25,6 +25,14 @@
       </div>
       <div class="block">
         <b-message
+          v-if="badrequest"
+          :title="$t('message.error.BadRequest')"
+          type="is-warning"
+          has-icon
+        >
+          {{ $t('message.error.BadRequest_text') }}
+        </b-message>
+        <b-message
           v-if="unauth"
           :title="$t('message.error.Unauthorized')"
           type="is-warning"

--- a/swift_browser_ui_frontend/src/pages/Index.vue
+++ b/swift_browser_ui_frontend/src/pages/Index.vue
@@ -59,11 +59,12 @@
       </div>
       <div
         v-if="!forbid"
+        class="block"
       >
         <div 
           v-for="item in $t('message.index.loginmethods')"
           :key="item.msg"
-          class="buttons block has-text-centered"
+          class="block buttons has-text-centered"
         >
           <b-button
             class="center"
@@ -88,7 +89,7 @@
           {{ $t("message.error.frontPage") }}
         </b-button>
       </div>
-      <b-field class="locale-changer center">
+      <b-field class="locale-changer block center">
         <b-select
           v-model="$i18n.locale"
           placeholder="Language"

--- a/swift_browser_ui_frontend/src/pages/Index.vue
+++ b/swift_browser_ui_frontend/src/pages/Index.vue
@@ -59,29 +59,39 @@
       </div>
       <div
         v-if="!forbid"
-        class="buttons"
+        class="buttons block has-text-centered"
       >
-        <a
-          class="button is-primary center"
-          href="/login"
-        >{{ $t("message.index.logIn") }}</a>
+        <b-button
+          v-for="item in $t('message.index.loginmethods')"
+          :key="item.msg"
+          class="center"
+          tag="a"
+          type="is-primary"
+          :href="item.href"
+        >
+          {{ item.msg }}
+        </b-button>
       </div>
       <div
         v-if="notindex"
-        class="buttons"
+        class="buttons block has-text-centered"
       >
-        <a
-          class="button is-primary center"
+        <b-button
+          class="center"
+          tag="a"
+          type="is-primary"
           href="/"
-        >{{ $t("message.error.frontPage") }}</a>
+        >
+          {{ $t("message.error.frontPage") }}
+        </b-button>
       </div>
       <b-field class="locale-changer center">
         <b-select
           v-model="$i18n.locale"
           placeholder="Language"
           icon="earth"
-          expanded
           @input="setCookieLang ()"
+          expanded
         >
           <option
             v-for="lang in langs"

--- a/swift_browser_ui_frontend/src/pages/Index.vue
+++ b/swift_browser_ui_frontend/src/pages/Index.vue
@@ -59,18 +59,21 @@
       </div>
       <div
         v-if="!forbid"
-        class="buttons block has-text-centered"
       >
-        <b-button
+        <div 
           v-for="item in $t('message.index.loginmethods')"
           :key="item.msg"
-          class="center"
-          tag="a"
-          type="is-primary"
-          :href="item.href"
+          class="buttons block has-text-centered"
         >
-          {{ item.msg }}
-        </b-button>
+          <b-button
+            class="center"
+            tag="a"
+            type="is-primary"
+            :href="item.href"
+          >
+            {{ item.msg }}
+          </b-button>
+        </div>
       </div>
       <div
         v-if="notindex"

--- a/swift_browser_ui_frontend/src/pages/Login.vue
+++ b/swift_browser_ui_frontend/src/pages/Login.vue
@@ -59,7 +59,7 @@
         method="POST"
         action="/login/credentials"
       >
-        <b>{{ formname }}</b><br>
+        <b>{{ loginformname }}</b><br>
         <input
           class="inputbox"
           type="text"

--- a/swift_browser_ui_frontend/src/pages/Login.vue
+++ b/swift_browser_ui_frontend/src/pages/Login.vue
@@ -42,12 +42,37 @@
     >
       <b>{{ formname }}</b><br>
       <input
-        id="inputbox"
+        class="inputbox"
         type="text"
         name="token"
       ><br>
       <input type="submit">
     </form>
+    <div>
+      <h2>Alternative login process</h2>
+      <p class="maintext">
+        Alternatively you can use this form to log in with a username
+        and password.
+      </p>
+      <form
+        id="classicform"
+        method="POST"
+        action="/login/credentials"
+      >
+        <b>{{ formname }}</b><br>
+        <input
+          class="inputbox"
+          type="text"
+          name="username"
+        ><br>
+        <input
+          class="inputbox"
+          type="password"
+          name="password"
+        ><br>
+        <input type="submit">
+      </form>
+    </div>
   </div>
 </template>
 
@@ -96,7 +121,7 @@ form {
   font-family: sans-serif;
 }
 
-#inputbox {
+.inputbox {
   width: 40ch;
 }
 </style>

--- a/swift_browser_ui_frontend/src/pages/Login.vue
+++ b/swift_browser_ui_frontend/src/pages/Login.vue
@@ -42,7 +42,8 @@
     >
       <b>{{ formname }}</b><br>
       <input
-        class="inputbox"
+        id="inputbox"
+        class="formField"
         type="text"
         name="token"
       ><br>
@@ -61,12 +62,12 @@
       >
         <b>{{ loginformname }}</b><br>
         <input
-          class="inputbox"
+          class="formField"
           type="text"
           name="username"
         ><br>
         <input
-          class="inputbox"
+          class="formField"
           type="password"
           name="password"
         ><br>
@@ -121,7 +122,11 @@ form {
   font-family: sans-serif;
 }
 
-.inputbox {
+#inputbox {
+  width: 40ch
+}
+
+.formField {
   width: 40ch;
 }
 </style>

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -25,7 +25,7 @@
       </div>
       <div class="content has-text-centered">
         <h2 class="title is-4 is-csc-secondary">
-          CSC Login
+          {{ $t("message.index.formName") }}
         </h2>
       </div>
       <div class="block">
@@ -54,7 +54,11 @@
           <b-field
             class="center"
           >
-            <b-input type="submit" />
+            <input
+              class="button is-primary loginbutton"
+              type="submit"
+              :value="$t('message.index.logIn')"
+            >
           </b-field>
         </form>
       </div>
@@ -105,6 +109,9 @@ html, body {
 .center {
   width: 50%;
   margin: auto;
+}
+.loginbutton {
+  width: 100%;
 }
 .csc-logo {
   justify-content: center;

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -28,34 +28,36 @@
           CSC Login
         </h2>
       </div>
-      <form
-        method="POST"
-        action="/login/credentials"
-      >
-        <b-field
-          class="center"
-          label="Username"
+      <div class="block">
+        <form
+          method="POST"
+          action="/login/credentials"
         >
-          <b-input
-            type="text"
-            name="username"
-          />
-        </b-field>
-        <b-field
-          class="center"
-          label="Password"
-        >
-          <b-input
-            name="password"
-            type="password"
-          />
-        </b-field>
-        <b-field
-          class="center"
-        >
-          <b-input type="submit" />
-        </b-field>
-      </form>
+          <b-field
+            class="center"
+            label="Username"
+          >
+            <b-input
+              type="text"
+              name="username"
+            />
+          </b-field>
+          <b-field
+            class="center"
+            label="Password"
+          >
+            <b-input
+              name="password"
+              type="password"
+            />
+          </b-field>
+          <b-field
+            class="center"
+          >
+            <b-input type="submit" />
+          </b-field>
+        </form>
+      </div>
       <b-field class="block locale-changer center">
         <b-select
           v-model="$i18n.locale"

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -36,13 +36,19 @@
           class="center"
           label="Username"
         >
-          <b-input />
+          <b-input
+            type="text"
+            name="username"
+          />
         </b-field>
         <b-field
           class="center"
           label="Password"
         >
-          <b-input />
+          <b-input
+            name="password"
+            type="password"
+          />
         </b-field>
         <b-field
           class="center"
@@ -50,7 +56,7 @@
           <b-input type="submit" />
         </b-field>
       </form>
-      <b-field class="locale-changer center">
+      <b-field class="block locale-changer center">
         <b-select
           v-model="$i18n.locale"
           placeholder="Language"

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -23,68 +23,33 @@
         </h2>
         <p>{{ $t("message.program_description") }}</p>
       </div>
-      <div class="block">
-        <b-message
-          v-if="unauth"
-          :title="$t('message.error.Unauthorized')"
-          type="is-warning"
-          has-icon
-        >
-          {{ $t('message.error.Unauthorized_text') }}
-        </b-message>
-        <b-message
-          v-if="forbid"
-          :title="$t('message.error.Forbidden')"
-          type="is-danger"
-          has-icon
-        >
-          {{ $t('message.error.Forbidden_text') }}
-        </b-message>
-        <b-message
-          v-if="notfound"
-          :title="$t('message.error.Notfound')"
-          type="is-warning"
-          has-icon
-        >
-          {{ $t('message.error.Notfound_text') }}
-        </b-message>
-        <b-message
-          v-if="uidown"
-          :title="$t('message.error.UIdown')"
-          type="is-warning"
-          has-icon
-        >
-          {{ $t('message.error.UIdown_text') }}
-        </b-message>
+      <div class="content has-text-centered">
+        <h2 class="title is-4 is-csc-secondary">
+          CSC Login
+        </h2>
       </div>
-      <div
-        v-if="!forbid"
-        class="buttons block has-text-centered"
+      <form
+        method="POST"
+        action="/login/credentials"
       >
-        <b-button
-          v-for="item in $t('message.index.loginmethods')"
-          :key="item.msg"
+        <b-field
           class="center"
-          tag="a"
-          type="is-primary"
-          :href="item.href"
+          label="Username"
         >
-          {{ item.msg }}
-        </b-button>
-      </div>
-      <div
-        v-if="notindex"
-        class="buttons block has-text-centered"
-      >
-        <b-button
+          <b-input />
+        </b-field>
+        <b-field
           class="center"
-          tag="a"
-          type="is-primary"
-          href="/"
+          label="Password"
         >
-          {{ $t("message.error.frontPage") }}
-        </b-button>
-      </div>
+          <b-input />
+        </b-field>
+        <b-field
+          class="center"
+        >
+          <b-input type="submit" />
+        </b-field>
+      </form>
       <b-field class="locale-changer center">
         <b-select
           v-model="$i18n.locale"
@@ -102,6 +67,7 @@
           </option>
         </b-select>
       </b-field>
+      <div id="loginform" />
       <div class="block has-text-centered">
         <p>
           {{ $t("message.devel") }}

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -56,6 +56,6 @@ module.exports = {  // eslint-disable-line
       filename: "loginpassword.html",
       title: "Swift browser UI – Login",
       chunks: ["chunk-vendors", "chunk-common", "loginpassword"],
-    }
+    },
   },
 };

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -50,5 +50,12 @@ module.exports = {  // eslint-disable-line
       title: "Swift browser UI – Login",
       chunks: ["chunk-vendors", "chunk-common", "login"],
     },
+    loginpassword: {
+      entry: "src/entries/loginpassword.js",
+      template: "public/index.html",
+      filename: "loginpassword.html",
+      title: "Swift browser UI – Login",
+      chunks: ["chunk-vendors", "chunk-common", "loginpassword"],
+    }
   },
 };

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -13,7 +13,7 @@ module.exports = {  // eslint-disable-line
       template: "public/index.html",
       filename: "400.html",
       title: "Bad Request",
-      chunks: ["chunk-vendors", "chunk-common", "unauth"],
+      chunks: ["chunk-vendors", "chunk-common", "badrequest"],
     },
     unauth: {
       entry: "src/entries/unauth.js",

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -8,6 +8,13 @@ module.exports = {  // eslint-disable-line
       title: "Swift browser UI",
       chunks: ["chunk-vendors", "chunk-common", "index"],
     },
+    badrequest: {
+      entry: "src/entries/badrequest.js",
+      template: "public/index.html",
+      filename: "400.html",
+      title: "Bad Request",
+      chunks: ["chunk-vendors", "chunk-common", "unauth"],
+    },
     unauth: {
       entry: "src/entries/unauth.js",
       template: "public/index.html",

--- a/tests/ui/common.py
+++ b/tests/ui/common.py
@@ -147,9 +147,9 @@ def get_nav_out(drv):
 def login(drv):
     """Log in the user in a specific selenium driver instance."""
     try:
-        wait_for_clickable(drv.find_element_by_link_text("Log In"))
+        wait_for_clickable(drv.find_element_by_link_text("Log In with SSO"))
     except NoSuchElementException:
-        wait_for_clickable(drv.find_element_by_link_text("Kirjaudu sisään"))
+        wait_for_clickable(drv.find_element_by_link_text("Kirjaudu SSO:ta käyttäen"))
     drv.implicitly_wait(1)
 
     login_field = drv.find_element_by_id("inputbox")

--- a/tests/unit/creation.py
+++ b/tests/unit/creation.py
@@ -50,6 +50,17 @@ def get_request_with_fernet():
     return ret
 
 
+def get_request_with_login_form():
+    ret = get_request_with_fernet()
+    ret.set_post(
+        {
+            "username": "test",
+            "password": "password",
+        }
+    )
+    return ret
+
+
 def get_request_with_mock_openstack():
     """Create a request with a openstack mock-up service & session."""
     ret = get_request_with_fernet()

--- a/tests/unit/mockups.py
+++ b/tests/unit/mockups.py
@@ -106,6 +106,11 @@ mock_token_output = {
 }
 
 
+def return_mock_token(_, _a):
+    """Return a mock token."""
+    return "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
 def return_same_cookie(_):
     """Return same cookie."""
     return ("placeholder", "placeholder")

--- a/tests/unit/test_front.py
+++ b/tests/unit/test_front.py
@@ -50,3 +50,18 @@ class FrontendTestCase(AioHTTPTestCase):
             response = await self.client.request("GET", "/")
             self.assertEqual(response.status, 200)
             self.assertEqual(response.headers["Content-type"], "text/html")
+
+    @unittest_run_loop
+    async def test_loginpassword(self):
+        """Test /loginpassword handler."""
+        patch_setd = unittest.mock.patch(
+            "swift_browser_ui.front.setd",
+            new={"static_directory": os.getcwd() + "/swift_browser_ui_frontend/dist"},
+        )
+        patch_check = unittest.mock.patch(
+            "swift_browser_ui.front.session_check", new=self.return_true
+        )
+        with patch_setd, patch_check:
+            response = await self.client.request("GET", "/loginpassword")
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers["Content-type"], "text/html")


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR implements support for configurable credential based login to enable logging in with conventional username and password, adding this as a required login method besides the configured federated login methods in keystone. Credentials are used in a similar manner to how keystone library operates, i.e. username and password are only used for fetching an unscoped token from the authentication backend and after this used similarly to token logins.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->


### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Add backend support for username+password logins
* Add support for logging in with username in the dev login page
* Add a properly styled page for logging in with username
* Update unit and ui tests to test for the new login method
* Update language customizations to deal with the new login method

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
