### PR TITLE
Bugfix/handle container 409

### DIFF
--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -101,7 +101,10 @@ async def swift_create_container(request: aiohttp.web.Request) -> aiohttp.web.Re
     # Return HTTPCreated upon a successful creation
     if res["success"]:
         return aiohttp.web.Response(status=201)
-    raise aiohttp.web.HTTPClientError(reason=res["error"])
+    if res["error"].http_status == 409:
+        request.app["Log"].info(res["error"].http_status)
+        raise aiohttp.web.HTTPConflict(reason="Container name in use")
+    raise aiohttp.web.HTTPServerError(reason=res["error"].msg)
 
 
 async def swift_delete_container(request: aiohttp.web.Request) -> aiohttp.web.Response:

--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -101,6 +101,8 @@ async def swift_create_container(request: aiohttp.web.Request) -> aiohttp.web.Re
     # Return HTTPCreated upon a successful creation
     if res["success"]:
         return aiohttp.web.Response(status=201)
+    if res["error"].http_status == 400:
+        raise aiohttp.web.HTTPBadRequest(reason="Invalid container name")
     if res["error"].http_status == 409:
         request.app["Log"].info(res["error"].http_status)
         raise aiohttp.web.HTTPConflict(reason="Container name in use")

--- a/swift_browser_ui/ui/middlewares.py
+++ b/swift_browser_ui/ui/middlewares.py
@@ -40,6 +40,8 @@ async def error_middleware(request: web.Request, handler: AiohttpHandler) -> web
             return return_error_response(403)
         if response.status == 404:
             return return_error_response(404)
+        if response.status == 409:
+            return response
         return response
     except web.HTTPException as ex:
         if ex.status == 400:
@@ -50,6 +52,8 @@ async def error_middleware(request: web.Request, handler: AiohttpHandler) -> web
             return return_error_response(403)
         if ex.status == 404:
             return return_error_response(404)
+        if ex.status == 409:
+            raise ex
         if ex.status > 404 and ex.status < 500:
             # we forbid all dubios and unauthorized requests
             return return_error_response(403)

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -237,6 +237,9 @@ export async function swiftCreateContainer (
     fetchURL, { method: "PUT", credentials: "same-origin" },
   );
   if (ret.status != 201) {
+    if (ret.status == 409) {
+      throw new Error("Container name already in use.");
+    }
     throw new Error("Container creation not successful.");
   }
 }

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -240,6 +240,9 @@ export async function swiftCreateContainer (
     if (ret.status == 409) {
       throw new Error("Container name already in use.");
     }
+    if (ret.status == 400) {
+      throw new Error("Invalid container name");
+    }
     throw new Error("Container creation not successful.");
   }
 }

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -37,6 +37,7 @@ let default_translations = {
                         "Otherwise head back to the front page from the " +
                         "button below.",
         inUse: "Bucket name already in use.",
+        invalidName: "Bucket name is invalid.",
         createFail: "Bucket creation failed.",
       },
       help: "Help",
@@ -259,6 +260,7 @@ let default_translations = {
                         "paluu etusivulle on mahdollista oheisesta " +
                         "painikkeesta",
         inUse: "Säiliön nimi on jo käytössä.",
+        invalidName: "Säiliön nimi ei kelpaa.",
         createFail: "Säiliön luonti epäonnistui.",
       },
       help: "Apua",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -36,6 +36,8 @@ let default_translations = {
                         "performed, contact the service administrator. " +
                         "Otherwise head back to the front page from the " +
                         "button below.",
+        inUse: "Bucket name already in use.",
+        createFail: "Bucket creation failed.",
       },
       help: "Help",
       helplink: "",
@@ -256,6 +258,8 @@ let default_translations = {
                         "yhteys palvelun ylläpitoon. Muussa tapauksessa " +
                         "paluu etusivulle on mahdollista oheisesta " +
                         "painikkeesta",
+        inUse: "Säiliön nimi on jo käytössä.",
+        createFail: "Säiliön luonti epäonnistui.",
       },
       help: "Apua",
       helplink: "",

--- a/swift_browser_ui_frontend/src/views/AddContainer.vue
+++ b/swift_browser_ui_frontend/src/views/AddContainer.vue
@@ -49,6 +49,24 @@ export default {
     createContainer: function () {
       swiftCreateContainer(this.container).then(() => {
         this.$router.go(-1);
+      }).catch((err) => {
+        console.log(err);
+        if (err.message.match("name")) {
+          this.$buefy.toast.open({
+            message: this.$t("message.error.inUse"),
+          });
+        }
+        else if (err.message.match("creation")) {
+          this.$buefy.toast.open({
+            message: this.$t("message.error.createFail"),
+          });
+        }
+        else {
+          this.$buefy.toast.open({
+            message: err.message,
+            type: "is-danger",
+          });
+        }
       });
     },
   },

--- a/swift_browser_ui_frontend/src/views/AddContainer.vue
+++ b/swift_browser_ui_frontend/src/views/AddContainer.vue
@@ -51,19 +51,21 @@ export default {
         this.$router.go(-1);
       }).catch((err) => {
         console.log(err);
-        if (err.message.match("name")) {
+        if (err.message.match("Container name already in use")) {
           this.$buefy.toast.open({
             message: this.$t("message.error.inUse"),
+            type: "is-danger",
           });
         }
-        else if (err.message.match("creation")) {
+        else if (err.message.match("Invalid container name")) {
           this.$buefy.toast.open({
-            message: this.$t("message.error.createFail"),
+            message: this.$t("message.error.invalidName"),
+            type: "is-danger",
           });
         }
         else {
           this.$buefy.toast.open({
-            message: err.message,
+            message: this.$t("message.error.createFail"),
             type: "is-danger",
           });
         }


### PR DESCRIPTION
### Description
This PR fixes bugs in container creation exception handling arising from the fact that openstack client doesn't let exceptions propagate, instead returning a response containing a success status of `error`. The behavior has now been corrected to take this into account.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes #272

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Let http errors properly propagate from Openstack Swift
* Alert user of the errors with an informational message in toast

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
