### PR TITLE
Bugfix/fix mime types

### DIFF
--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -287,9 +287,9 @@ async def swift_download_object(request: aiohttp.web.Request) -> aiohttp.web.Res
         status=302,
     )
     response.headers["Location"] = dloadurl
-    response.headers["Content-Type"] = dict(
-        list(serv.stat(request.query["bucket"], [request.query["objkey"]]))[0]["items"]
-    )["Content Type"]
+    response.headers["Content-Type"] = list(
+        serv.stat(request.query["bucket"], [request.query["objkey"]])
+    )[0]["headers"]["content-type"]
     return response
 
 

--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -287,6 +287,9 @@ async def swift_download_object(request: aiohttp.web.Request) -> aiohttp.web.Res
         status=302,
     )
     response.headers["Location"] = dloadurl
+    response.headers["Content-Type"] = dict(
+        list(serv.stat(request.query["bucket"], [request.query["objkey"]]))[0]["items"]
+    )["Content Type"]
     return response
 
 

--- a/swift_browser_ui/upload/upload.py
+++ b/swift_browser_ui/upload/upload.py
@@ -209,6 +209,7 @@ class ResumableFileUploadProxy:
                 headers={
                     "X-Auth-Token": self.auth.get_token(),
                     "Content-Length": str(self.total_size),
+                    "Content-Type": str(self.content_type),
                 },
                 timeout=UPL_TIMEOUT,
                 ssl=ssl_context,

--- a/tests/ui_unit/mock_server.py
+++ b/tests/ui_unit/mock_server.py
@@ -42,6 +42,11 @@ def mock_initiate_swift_service(_):
         # with envvar.
         size_range=(1, int(environ.get("TEST_MAX_OBJECT_SIZE", 1048576))),
     )
+    # Add mock data for object metadata
+    for key in serv.containers.keys():
+        serv.set_swift_meta_container(key)
+        for obj in serv.containers[key]:
+            serv.set_swift_meta_object(key, obj["name"])
     # The downloads aren't mocked, so no contents to any file. This isn't
     # something we need to test, and also would consume too much resources.
     # NOTE: Some random metadata creation could be added here.

--- a/tests/ui_unit/mockups.py
+++ b/tests/ui_unit/mockups.py
@@ -351,6 +351,7 @@ class Mock_Service:
                     i
                 ]["Obj_S3_example"]
             to_add["success"] = True
+            to_add["headers"]["content-type"] = "binary/octet-stream"
             to_add["object"] = i
             ret.append(to_add)
         return ret

--- a/tests/ui_unit/test_api.py
+++ b/tests/ui_unit/test_api.py
@@ -159,7 +159,14 @@ class APITestClass(asynctest.TestCase):
         container = "test-container-0"
         o_name = self.request.app["Sessions"][self.cookie]["ST_conn"].containers[
             container
-        ][0]
+        ][0]["name"]
+
+        self.request.app["Sessions"][self.cookie]["ST_conn"].set_swift_meta_container(
+            "test-container-0"
+        )
+        self.request.app["Sessions"][self.cookie]["ST_conn"].set_swift_meta_object(
+            "test-container-0", o_name
+        )
 
         self.request.query["bucket"] = container
         self.request.query["objkey"] = o_name


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR passes through the mime types in upload runner, as well as implements them upon the HTTP 302 when serving files. Files uploaded via UI will now have the correct mime type header in the storage, instead of defaulting to `binary/octet-stream`.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes #170 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Pass mime types from `resumable.js` uploads to Swift
* Use correct mime type when initiating downloads, as `aiohttp` does not give an easy solution to omitting `Content-Type' header altogether.
* Alter unit tests to work with the new behavior

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
