### PR TITLE
remove auth checks from health checks

### DIFF
--- a/swift_browser_ui/common/common_middleware.py
+++ b/swift_browser_ui/common/common_middleware.py
@@ -63,6 +63,9 @@ async def handle_validate_authentication(
     handler: swift_browser_ui.common.types.AiohttpHandler,
 ) -> aiohttp.web.Response:
     """Handle the authentication of a response as a middleware function."""
+    if request.path == "/health":
+        return await handler(request)
+
     try:
         signature = request.query["signature"]
         validity = request.query["valid"]

--- a/swift_browser_ui/request/api.py
+++ b/swift_browser_ui/request/api.py
@@ -123,12 +123,12 @@ async def handle_health_check(request: aiohttp.web.Request) -> aiohttp.web.Respo
     """Answer a service health check."""
     # Case degraded
     try:
-        if request.app["db_conn"].conn.is_closed():
-            MODULE_LOGGER.log(logging.DEBUG, "Database closed")
+        if request.app["db_conn"].pool is None:
+            MODULE_LOGGER.log(logging.ERROR, "No database connection available")
             return aiohttp.web.json_response(
                 {"status": "Degraded", "degraded": ["database"]}
             )
-    except AttributeError:
+    except (KeyError, AttributeError):
         MODULE_LOGGER.log(logging.ERROR, "Degraded Database")
         return aiohttp.web.json_response({"status": "Degraded", "degraded": ["database"]})
 

--- a/swift_browser_ui/sharing/api.py
+++ b/swift_browser_ui/sharing/api.py
@@ -191,12 +191,12 @@ async def handle_health_check(request: aiohttp.web.Request) -> aiohttp.web.Respo
     """Answer a service health check."""
     # Case degraded
     try:
-        if request.app["db_conn"].conn.is_closed():
-            MODULE_LOGGER.log(logging.DEBUG, "Database closed")
+        if request.app["db_conn"].pool is None:
+            MODULE_LOGGER.log(logging.ERROR, "No database connection available")
             return aiohttp.web.json_response(
                 {"status": "Degraded", "degraded": ["database"]}
             )
-    except AttributeError:
+    except (KeyError, AttributeError):
         MODULE_LOGGER.log(logging.ERROR, "Degraded Database")
         return aiohttp.web.json_response({"status": "Degraded", "degraded": ["database"]})
 

--- a/swift_browser_ui/upload/auth.py
+++ b/swift_browser_ui/upload/auth.py
@@ -38,6 +38,9 @@ async def handle_validate_authentication(
     handler: swift_browser_ui.common.types.AiohttpHandler,
 ) -> aiohttp.web.Response:
     """Handle the authentication of a response as a middleware function."""
+    if request.path == "/health":
+        return await handler(request)
+
     try:
         signature = request.query["signature"]
         validity = request.query["valid"]

--- a/swift_browser_ui/upload/server.py
+++ b/swift_browser_ui/upload/server.py
@@ -53,9 +53,9 @@ async def servinit() -> aiohttp.web.Application:
     # Add auth related routes
     # Can use direct project post for creating a session, as it's intuitive
     # and POST upload against an account doesn't exist
-    app.add_routes([aiohttp.web.post("/{project}", handle_login)])
-
     app.add_routes([aiohttp.web.get("/health", handle_health_check)])
+
+    app.add_routes([aiohttp.web.post("/{project}", handle_login)])
 
     # Add api routes
     app.add_routes(

--- a/tests/common/mockups.py
+++ b/tests/common/mockups.py
@@ -179,6 +179,7 @@ class Mock_Request:
         self.match_info = {}
         self.remote = "127.0.0.1"
         self.url = yarl.URL("http://localhost:8080")
+        self.path = "/"
         self.post_data = {}
 
     def set_headers(self, headers):
@@ -214,6 +215,9 @@ class Mock_Request:
     def set_post(self, data):
         """Set post data."""
         self.post_data = data
+
+    def set_path(self, path):
+        self.path = path
 
     async def post(self):
         """Return post data."""

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -50,6 +50,7 @@ class AuthTestClass(asynctest.TestCase):
         """Test swift_browser_ui.upload.auth.handle_validate_authentication."""
         handler_mock = asynctest.CoroutineMock()
         req = tests.common.mockups.Mock_Request()
+        req.set_path("/")
 
         t_singature_mock = asynctest.CoroutineMock()
         t_signature_patch = unittest.mock.patch(
@@ -75,3 +76,16 @@ class AuthTestClass(asynctest.TestCase):
                 req, handler_mock
             )
         handler_mock.assert_called_once()
+
+    async def test_handle_validate_authentication_health_endpoint(self):
+        """Test handle_validate_authentication with health endpoint."""
+        req = tests.common.mockups.Mock_Request()
+        req.set_path("/health")
+
+        handler_mock = asynctest.CoroutineMock()
+
+        await swift_browser_ui.upload.auth.handle_validate_authentication(
+            req,
+            handler_mock,
+        )
+        handler_mock.assert_awaited_once()


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
There were unnecessary authentication checks in place, leading to health check endpoint not working as intended. This PR fixes `/health` endpoint behavior.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Create an exception for the auth middleware concerning `/health` endpoints in `swift_browser_ui.sharing`, `swift_browser_ui.request`, `swift_browser_ui.upload` health checks
* Alter unit tests to take new behavior into account
* Fix incorrect ordering of `swift_browser_ui.upload` routes to make `/health` endpoint precede wildcard route for projects

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
