### PR TITLE
truncate name of containers and objects in tables and breadcrumb

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           pushd swift_browser_ui_frontend
           sudo npm install -g npm@7.24.1
-          npm install
+          npm ci
       - name: Run eslint
         run: |
           pushd swift_browser_ui_frontend

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           pushd swift_browser_ui_frontend
+          sudo npm install -g npm@7.24.1
           npm install
       - name: Run eslint
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Install frontend
       run: |
         pushd swift_browser_ui_frontend
+        sudo npm install -g npm@7.24.1
         npm install
         npm run build
     - name: Run unit tests

--- a/swift_browser_ui_frontend/src/components/Breadcrumb.vue
+++ b/swift_browser_ui_frontend/src/components/Breadcrumb.vue
@@ -4,7 +4,7 @@
       class="breadcrumb-link"
       :to="address"
     >
-      {{ alias }}
+      {{ alias | truncate(100) }}
     </router-link>
   </li>
 </template>
@@ -12,6 +12,11 @@
 <script>
 export default {
   name: "BreadcrumbListElement",
+  filters: {
+    truncate(value, length) {
+      return value.length > length ? value.substr(0, length) + "..." : value;
+    },
+  },
   props: ["address", "alias"],
 };
 </script>

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -126,13 +126,13 @@
           <b-icon
             icon="folder"
             size="is-small"
-          /> <b>{{ getFolderName(props.row.name) }}</b>
+          /> <b>{{ getFolderName(props.row.name) | truncate(100) }}</b>
         </span>
         <span v-else-if="renderFolders">
-          {{ props.row.name.replace(getPrefix(), '') }}
+          {{ props.row.name.replace(getPrefix(), '') | truncate(100) }}
         </span>
         <span v-else>
-          {{ props.row.name }}
+          {{ props.row.name | truncate(100) }}
         </span>
       </b-table-column>
       <b-table-column
@@ -314,6 +314,11 @@ export default {
     FolderUploadForm,
     ReplicateContainerButton,
     DeleteObjectsButton,
+  },
+  filters:{
+    truncate(value, length) {
+      return value.length > length ? value.substr(0, length) + "..." : value;
+    },
   },
   data: function () {
     return {

--- a/swift_browser_ui_frontend/src/components/ShareRequestsTable.vue
+++ b/swift_browser_ui_frontend/src/components/ShareRequestsTable.vue
@@ -48,7 +48,7 @@
         :label="$t('message.share.container')"
       >
         <template #default="props">
-          {{ props.row.container }}
+          {{ props.row.container |truncate(80) }}
         </template>
       </b-table-column>
       <b-table-column
@@ -99,6 +99,11 @@ import delay from "lodash/delay";
 
 export default {
   name: "ShareRequestsTable",
+  filters: {
+    truncate(value, length) {
+      return value.length > length ? value.substr(0, length) + "..." : value;
+    },
+  },
   data () {
     return {
       perPage: 10,

--- a/swift_browser_ui_frontend/src/components/SharedTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedTable.vue
@@ -58,7 +58,7 @@
               icon="folder"
               size="is-small"
             />
-            {{ props.row.container }}
+            {{ props.row.container | truncate(80) }}
           </span>
         </template>
       </b-table-column>
@@ -128,6 +128,11 @@ export default {
   components: {
     ContainerDownloadLink,
     ReplicateContainerButton,
+  },
+  filters: {
+    truncate(value, length) {
+      return value.length > length ? value.substr(0, length) + "..." : value;
+    },
   },
   data: function () {
     return {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -92,7 +92,7 @@
               icon="folder-outline"
               size="is-small"
             /> 
-            {{ props.row.name }}
+            {{ props.row.name | truncate(100) }}
           </span>
           <span
             v-else
@@ -102,7 +102,7 @@
               icon="folder"
               size="is-small"
             /> 
-            {{ props.row.name }}
+            {{ props.row.name | truncate(100) }}
           </span>
         </template>
       </b-table-column>
@@ -280,6 +280,11 @@ export default {
     ContainerDownloadLink,
     ReplicateContainerButton,
     DeleteContainerButton,
+  },
+  filters:{
+    truncate(value, length) {
+      return value.length > length ? value.substr(0, length) + "..." : value;
+    },
   },
   data: function () {
     return {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #306 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. truncate table long names for objects, container and shared containers
2. truncate breadcrumbs long names
3. fix npm version for github actions

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
when we implement tablet ui we might need to add come more css styles to adjust this.