### PR TITLE
typo: Containers -> ContainersView

### DIFF
--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -281,7 +281,7 @@ new Vue({
           retl.push({
             alias: this.$t("message.containers")
                    + this.$store.state.active.name,
-            address: {name: "Containers"},
+            address: {name: "ContainersView"},
           });
         }
       }


### PR DESCRIPTION
### Description
After the refactoring in #390, it was missing to rename `Containers` -> `ContainersView` in `getRouteAsList()`.
This prevented `vue-router` from creating proper breadcrumb links.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Renamed `Containers` -> `ContainersView` in `getRouteAsList()`.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
