### PR TITLE
Return empty list of buckets, fixes #356

### DIFF
--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -67,11 +67,6 @@ async def swift_list_buckets(request: aiohttp.web.Request) -> aiohttp.web.Respon
         # response at once
         serv = request.app["Sessions"][session]["ST_conn"].list()
         [_unpack(i, cont, request) for i in serv]
-        # for a bucket with no objects
-        if not cont:
-            # return empty object
-            request.app["Log"].debug("Empty container list.")
-            raise aiohttp.web.HTTPNotFound()
         return aiohttp.web.json_response(cont)
     except SwiftError:
         request.app["Log"].error("SwiftError occured return empty container list.")

--- a/tests/ui_unit/test_api.py
+++ b/tests/ui_unit/test_api.py
@@ -107,10 +107,11 @@ class APITestClass(asynctest.TestCase):
         )
 
     async def test_list_without_containers(self):
-        """Test function list buckets on a project without object storage."""
+        """Test function list buckets on a project without containers."""
         self.request.app["Sessions"][self.cookie]["ST_conn"].init_with_data(containers=0)
-        with self.assertRaises(HTTPNotFound):
-            _ = await swift_list_buckets(self.request)
+        response = await swift_list_buckets(self.request)
+        objects = json.loads(response.text)
+        self.assertEqual(objects, [])
 
     async def test_list_with_invalid_container(self):
         """Test function list objects with an invalid container id."""


### PR DESCRIPTION
### Description

The backend was returning an HTTP 404 when there were no buckets.
This caused the frontend to not refresh the bucket list UI when the last bucket was deleted.

### Related issues
Fixes #356.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Removed HTTP 404 return when there are no buckets.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
