### PR TITLE
Fix breadcrumbs by changing URLs

### DIFF
--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -40,7 +40,7 @@ export default new Router({
       component: SharingView,
     },
     {
-      path: "/browse/:user/:project/:container/add",
+      path: "/browse/:user/:project/add",
       name: "AddContainer",
       component: CreateContainer,
     },

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -20,22 +20,22 @@ export default new Router({
   mode: "history",
   routes: [
     {
-      path: "/browse/sharing/to/:project",
+      path: "/browse/:user/:project/sharing/to",
       name: "SharedTo",
       component: SharedTo,
     },
     {
-      path: "/browse/sharing/from/:project",
+      path: "/browse/:user/:project/sharing/from",
       name: "SharedFrom",
       component: SharedFrom,
     },
     {
-      path: "/browse/sharing/requests/:project",
+      path: "/browse/:user/:project/sharing/requests",
       name: "ShareRequests",
       component: ShareRequests,
     },
     {
-      path: "/browse/sharing/share",
+      path: "/browse/:user/:project/sharing/share",
       name: "SharingView",
       component: SharingView,
     },
@@ -45,27 +45,27 @@ export default new Router({
       component: CreateContainer,
     },
     {
-      path: "/browse/sharing/requestdirect",
+      path: "/browse/:user/:project/sharing/requestdirect",
       name: "DirectRequest",
       component: DirectRequest,
     },
     {
-      path: "/browse/sharing/sharedirect",
+      path: "/browse/:user/:project/sharing/sharedirect",
       name: "DirectShare",
       component: DirectShare,
     },
     {
-      path: "/browse/shared/:project/:owner/:container",
+      path: "/browse/:user/:project/:container/shared/:owner",
       name: "SharedObjects",
       component: SharedObjects,
     },
     {
-      path: "/browse/replicate/:project/:container",
+      path: "/browse/:user/:project/:container/replicate",
       name: "ReplicateContainer",
       component: ReplicationView,
     },
     {
-      path: "/browse/tokens/:project",
+      path: "/browse/:user/:project/tokens",
       name: "TokensView",
       component: TokensView,
     },

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -40,7 +40,7 @@ export default new Router({
       component: SharingView,
     },
     {
-      path: "/browse/container/add",
+      path: "/browse/:user/:project/:container/add",
       name: "AddContainer",
       component: CreateContainer,
     },


### PR DESCRIPTION
### Description
Making URLs look similar, basically adding parameters to the ones that didn't have them.
This is a relatively simple change which makes the frontend pass on more parameters between pages. The breadcrumb function expects these parameters to be available. When they are not, the functionality is broken.

### Related issues
Fixes #417.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Changed the routes in the frontend to include more parameters.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

<!-- - [ ] Unit Tests -->
<!-- - [ ] Integration Tests -->
- [x] Tests do not apply
<!-- - [ ] Needs testing (start an issue or do a follow up PR about it) -->

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
