### PR TITLE
Allow a person to tag buckets.

### DIFF
--- a/docs/_static/api.yml
+++ b/docs/_static/api.yml
@@ -747,6 +747,37 @@ paths:
           description: Unauthorized
         404:
           description: Not Found
+    post:
+      tags:
+        - Frontend
+      summary: Update user created container metadata.
+      parameters:
+        - name: container
+          in: query
+          description: The container which metadata will be updated.
+          schema:
+            type: string
+            example: test-container-1
+          required: true
+      requestBody:
+        description: Bucket metadata as a key-value object. Updates must include all the metadata for the bucket. Omitted keys are removed by the swift backend.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+              example:
+                owner: project-team
+      responses:
+        204:
+          description: Container metadata was updated. No Content.
+        403:
+          description: Unauthorized
+        404:
+          description: Container was not found
   /api/shared/objects:
     get:
       tags:

--- a/swift_browser_ui/ui/server.py
+++ b/swift_browser_ui/ui/server.py
@@ -44,6 +44,7 @@ from swift_browser_ui.ui.api import (
     swift_upload_object_chunk,
     swift_check_object_chunk,
     swift_replicate_container,
+    update_metadata_bucket,
 )
 from swift_browser_ui.ui.health import handle_health_check
 from swift_browser_ui.ui.settings import setd
@@ -158,6 +159,7 @@ async def servinit() -> aiohttp.web.Application:
             aiohttp.web.get("/api/projects", os_list_projects),
             aiohttp.web.get("/api/project/active", get_os_active_project),
             aiohttp.web.get("/api/bucket/meta", get_metadata_bucket),
+            aiohttp.web.post("/api/bucket/meta", update_metadata_bucket),
             aiohttp.web.get("/api/bucket/object/meta", get_metadata_object),
             aiohttp.web.get("/api/project/meta", get_project_metadata),
             aiohttp.web.get("/api/project/acl", get_access_control_metadata),

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -72,6 +72,40 @@ export async function getBuckets () {
   return buckets;
 }
 
+export async function getBucketMeta (
+  container,
+){
+  let url = new URL(
+    "/api/bucket/meta?container=".concat(encodeURI(container)),
+    document.location.origin,
+  );
+
+  let ret = await fetch(
+    url, {method: "GET", credentials: "same-origin"},
+  );
+  return ret.json();
+}
+
+export async function updateBucketMeta (
+  container,
+  metadata,
+){
+  let url = new URL(
+    "/api/bucket/meta?container=".concat(encodeURI(container)),
+    document.location.origin,
+  );
+
+  let ret = await fetch(
+    url,
+    {
+      method: "POST",
+      credentials: "same-origin",
+      body: JSON.stringify(metadata),
+    },
+  );
+  return ret;
+}
+
 export async function getObjects (container) {
   // Fetch objects contained in a container from the API for the user
   // that's currently logged in.
@@ -227,21 +261,29 @@ export async function getSharedContainerAddress () {
 
 export async function swiftCreateContainer (
   container,
+  tags,
 ) {
   // Create a container matching the specified name.
   let fetchURL = new URL( "/api/containers/".concat(
     container,
   ), document.location.origin);
 
+  let body = {
+    tags,
+  };
   let ret = await fetch(
-    fetchURL, { method: "PUT", credentials: "same-origin" },
+    fetchURL, { 
+      method: "PUT", 
+      credentials: "same-origin",
+      body: JSON.stringify(body),
+    },
   );
   if (ret.status != 201) {
     if (ret.status == 409) {
       throw new Error("Container name already in use.");
     }
     if (ret.status == 400) {
-      throw new Error("Invalid container name");
+      throw new Error("Invalid container or tag name");
     }
     throw new Error("Container creation not successful.");
   }

--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -1,3 +1,8 @@
+
+import {
+  getBucketMeta,
+} from "./api";
+
 export default function getLangCookie () {
   let matches = document.cookie.match(new RegExp(
     "(?:^|; )" + "OBJ_UI_LANG" + "=([^;]*)",
@@ -50,4 +55,14 @@ export function getHumanReadableSize (val) {
       break;
   }
   return ret;
+}
+
+export async function getTagsForContainer(containerName) {
+  let tags = [];
+  await getBucketMeta(containerName).then(meta => {
+    if ("usertags" in meta[1]) {
+      tags = meta[1]["usertags"].split(";");
+    }
+  });
+  return tags;
 }

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -63,6 +63,7 @@ let default_translations = {
         created: "Created",
         folderDetails: "No details for folders",
         clearChecked: "Clear checked",
+        showTags: "Display tags",
       },
       discover: {
         sync_shares: "Synchronize shared buckets",
@@ -185,12 +186,15 @@ let default_translations = {
       copy: " Copy",
       create: "Create",
       delete: "Delete",
+      edit: "Edit",
+      save: "Save",
       createContainerButton: "Create Bucket",
       copysuccess: "Started copying the bucket in the background",
       copyfail: "Failed to copy the bucket",
       renderFolders: "Render as Folders",
       container_ops: {
         addContainer: "Add a new bucket",
+        editContainer: "Editing bucket: ",
         deleteConfirm: "Delete Bucket",
         deleteConfirmMessage: "Are you sure you want to delete this " +
                               "bucket?",
@@ -199,6 +203,8 @@ let default_translations = {
         containerMessage: "The name of the new bucket",
         fullDelete: "Deleting a bucket with contents requires deleting " +
                     "all objects inside it first.",
+        tagName: "Tags",
+        tagMessage: "Press enter to add.",
       },
       objects: {
         deleteConfirm: "Delete Objects",
@@ -286,6 +292,7 @@ let default_translations = {
         created: "Luotu",
         folderDetails: "Ei yksityiskohtia kansioille",
         clearChecked: "Poista valinnat",
+        showTags: "Näytä Tägit",
       },
       discover: {
         sync_shares: "Synkronoi jaetut säiliöt",
@@ -409,18 +416,23 @@ let default_translations = {
       copy: " Kopioi",
       create: "Luo",
       delete: "Poista",
+      edit: "Muokkaa",
+      save: "Tallenna",
       createContainerButton: "Luo säiliö",
       copysuccess: "Aloitettiin säiliön kopiointi taustalla",
       copyfail: "Säiliön kopiointi epäonnistui",
       renderFolders: "Näytä kansioina",
       container_ops: {
         addContainer: "Luo uusi säiliö",
+        editContainer: "Muokataan säiliötä: ",
         deleteConfirm: "Poista säiliö",
         deleteConfirmMessage: "Haluatko varmasti poistaa tämän säiliön?",
         deleteSuccess: "Säiliö poistettu",
         containerName: "Säiliö",
         containerMessage: "Uuden säiliön nimi",
         fullDelete: "Säiliön sisältö on poistettava ennen säiliön postamista.",
+        tagName: "Tägit",
+        tagMessage: "Paina 'enter' lisätäksesi.",
       },
       objects: {
         deleteConfirm: "Poista objektit",

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -45,6 +45,11 @@ export default new Router({
       component: CreateContainer,
     },
     {
+      path: "/browse/:user/:project/:container/edit",
+      name: "EditContainer",
+      component: CreateContainer,
+    },
+    {
       path: "/browse/:user/:project/sharing/requestdirect",
       name: "DirectRequest",
       component: DirectRequest,

--- a/swift_browser_ui_frontend/src/components/ContainerDeleteButton.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerDeleteButton.vue
@@ -55,7 +55,7 @@ export default {
         type: "is-success",
       });
       swiftDeleteContainer(this.container).then(() => {
-        this.$store.commit("updateContainers");
+        this.$store.dispatch("updateContainers");
       });
     },
   },

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -205,7 +205,7 @@ new Vue({
     endUpload: function () {
       this.$store.commit("eraseAltContainer");
       this.$store.commit("stopUploading");
-      this.$store.commit("updateContainers");
+      this.$store.dispatch("updateContainers");
       window.onbeforeunload = undefined;
     },
     startChunking: function () {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -33,11 +33,17 @@
         </option>
       </b-select>
       <div class="control is-flex">
-        <b-switch 
+        <b-switch
           v-if="bList.length < 500"
           v-model="isPaginated"
+          data-testid="paginationSwitch"
         >
           {{ $t('message.table.paginated') }}
+        </b-switch>
+        <b-switch
+          v-model="showTags"
+        >
+          {{ $t('message.table.showTags') }}
         </b-switch>
       </div>
       <b-field class="control searchBox">
@@ -87,23 +93,26 @@
         :label="$t('message.table.name')"
       >
         <template #default="props">
-          <span v-if="!props.row.count">
-            <b-icon
-              icon="folder-outline"
-              size="is-small"
-            /> 
-            {{ props.row.name | truncate(100) }}
-          </span>
-          <span
-            v-else
-            class="has-text-weight-bold"
+          <span 
+            :class="props.row.count ? 'has-text-weight-bold' : ''"
           >
             <b-icon
-              icon="folder"
+              :icon="props.row.count ? 'folder' : 'folder-outline'"
               size="is-small"
-            /> 
+            />
             {{ props.row.name | truncate(100) }}
           </span>
+          <b-taglist v-if="showTags">
+            <b-tag
+              v-for="tag in tags[props.row.name]"
+              :key="tag"
+              :type="selected==props.row ? 'is-primary-invert' : 'is-primary'"
+              rounded
+              ellipsis
+            >
+              {{ tag }}
+            </b-tag>
+          </b-taglist>
         </template>
       </b-table-column>
       <b-table-column
@@ -231,6 +240,22 @@
                 :smallsize="true"
               />
             </p>
+            <p class="control">
+              <b-button
+                tag="router-link"
+                type="is-primary"
+                outlined
+                size="is-small"
+                icon-left="pencil"
+                :inverted="selected==props.row ? true : false"
+                :to="{
+                  name: 'EditContainer',
+                  params: {container: props.row.name}
+                }"
+              >
+                {{ $t('message.edit') }}
+              </b-button>
+            </p>
           </div>
         </template>
       </b-table-column>
@@ -291,6 +316,7 @@ export default {
       files: [],
       folders: [],
       bList: [],
+      tags: {},
       selected: undefined,
       isPaginated: true,
       perPage: 15,
@@ -298,6 +324,7 @@ export default {
       searchQuery: "",
       currentPage: 1,
       shareModalIsActive: false,
+      showTags: true,
     };
   },
   computed: {
@@ -307,6 +334,9 @@ export default {
     containers () {
       return this.$store.state.containerCache;
     },
+    containerTags() {
+      return this.$store.state.containerTagsCache;
+    },
   },
   watch: {
     searchQuery: function () {
@@ -315,6 +345,9 @@ export default {
     },
     containers: function () {
       this.bList = this.containers;
+    },
+    containerTags: function () {
+      this.tags = this.containerTags; // {"containerName": ["tag1", "tag2"]}
     },
   },
   created: function () {
@@ -329,11 +362,11 @@ export default {
     this.fetchContainers();
   },
   methods: {
-    fetchContainers: function () {
+    fetchContainers: async function () {
       // Get the container listing from the API if the listing hasn't yet
       // been cached.
       if(this.bList.length < 1) {
-        this.$store.commit("updateContainers");
+        await this.$store.dispatch("updateContainers");
       }
     },
     checkPageFromRoute: function () {

--- a/swift_browser_ui_frontend/src/views/Replicate.vue
+++ b/swift_browser_ui_frontend/src/views/Replicate.vue
@@ -89,7 +89,7 @@ export default {
           message: this.$t("message.copysuccess"),
           type: "is-success",
         });
-        this.$store.commit("updateContainers");
+        this.$store.dispatch("updateContainers");
         this.$router.go(-1);
       }).catch(() => {
         this.$buefy.toast.open({

--- a/tests/cypress/integration/browser.spec.js
+++ b/tests/cypress/integration/browser.spec.js
@@ -11,7 +11,7 @@ describe("Browse buckets and test operations", function () {
   it("should be able to filter table, adjust display buckets per page and pagination", () => {
     cy.get('[data-testid="bucketsPerPage"]').select('5 per page')
     cy.contains('1-5 / 10')
-    cy.contains('Paginated').parent().click()
+    cy.get('[data-testid="paginationSwitch"]').click()
     cy.get('[data-testid="bucketsPerPage"]').should('be.disabled')
     cy.get('.input').type('test-container-5')
   })
@@ -24,7 +24,7 @@ describe("Browse buckets and test operations", function () {
         .within(() => {
           cy.get('td').eq(0).then(($elem) => {
             cy.get($elem).dblclick()
-            cy.url().should('eq', Cypress.config().baseUrl + '/browse/test_user_id/placeholder/' + $elem.get(0).innerText.trim())
+            cy.url().should('eq', Cypress.config().baseUrl + '/browse/test_user_id/placeholder/' + $elem.get(0).innerText.split('\n')[0].trim())
             cy.wait(2000)
             
           })
@@ -64,4 +64,33 @@ describe("Browse buckets and test operations", function () {
 
   })
 
+  it("should display, add, remove tags", () => {
+    // container list loads with tags
+    cy.get('tbody .tags .tag').should('have.length', 40)
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 4)
+    
+    // // remove one tag
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('h1').should('contain', 'Editing bucket')
+    cy.get('.delete').first().click()
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 3)
+
+    // // add few tags
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('.taginput input').type('adding.couple more')
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 6)
+
+    // remove all tags from a bucket
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('.taginput-container').children('span').should('have.length', 6)
+    cy.get('.delete').each(el => {
+      cy.get('.delete').first().click()
+      cy.wait(100)
+    });
+    cy.get('.taginput-container').children('span').should('have.length', 0)
+    cy.get('button').contains('Save').click()
+    cy.get('tbody .tags .tag').should('have.length', 36)
+  })
 })


### PR DESCRIPTION
### Description
Gives a person the possibility to add or remove tags from a bucket. Includes the ability to show or hide tags when browsing the buckets.
<!-- Please include a summary of the change or any information deemed important. -->

Please, check the Finnish language :) 

### Related issues
Related to #85.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
Added backend for updating metadata for a bucket. Added UI for displaying tags for containers, as well as hiding them. There is a new button, called 'Edit', which makes it possible to edit a bucket's tags. When creating a new Bucket, it's possible to add tags to it.

Tags are not displayed in the bucket view (after double click on a bucket). There's no edit button on that page either.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
Thanks to @sampsapenna for solving my javascript sync/async mess.
