### PR TITLE
Refactor: pass icon as props to button.

### DIFF
--- a/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
@@ -7,11 +7,9 @@
     target="_blank"
     :inverted="inverted"
     disabled
+    icon-left="download"
   >
-    <b-icon
-      icon="download"
-      size="is-small"
-    /> {{ $t('message.downloadContainer') }}
+    {{ $t('message.downloadContainer') }}
   </b-button>
   <b-button
     v-else
@@ -21,11 +19,9 @@
     target="_blank"
     :inverted="inverted"
     :href="download_link"
+    icon-left="download"
   >
-    <b-icon
-      icon="download"
-      size="is-small"
-    /> {{ $t('message.downloadContainer') }}
+    {{ $t('message.downloadContainer') }}
   </b-button>
 </template>
 

--- a/swift_browser_ui_frontend/src/components/FolderUpload.vue
+++ b/swift_browser_ui_frontend/src/components/FolderUpload.vue
@@ -4,12 +4,10 @@
       v-if="isUploading"
       type="is-primary"
       outlined
+      icon-left="cancel"
       @click="res.cancel()"
     >
-      <b-icon
-        icon="cancel"
-        size="is-small"
-      />{{ $t('message.cancelupload') }}
+      {{ $t('message.cancelupload') }}
     </b-button>
     <UploadButton
       v-else

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -179,11 +179,9 @@
                 outlined
                 size="is-small"
                 tag="a"
+                icon-left="download"
               >
-                <b-icon
-                  icon="download"
-                  size="is-small"
-                /> {{ $t('message.download') }}
+                {{ $t('message.download') }}
               </b-button>
               <b-button
                 v-else-if="allowLargeDownloads"
@@ -195,11 +193,9 @@
                 outlined
                 size="is-small"
                 tag="a"
+                icon-left="download"
               >
-                <b-icon
-                  icon="download"
-                  size="is-small"
-                /> {{ $t('message.download') }}
+                {{ $t('message.download') }}
               </b-button>
               <b-button
                 v-else
@@ -209,12 +205,10 @@
                 :inverted="props.row === selected ? true : false"
                 size="is-small"
                 tag="a"
+                icon-left="download"
                 @click="confirmDownload ()"
               >
-                <b-icon
-                  icon="download"
-                  size="is-small"
-                /> {{ $t('message.download') }}
+                {{ $t('message.download') }}
               </b-button>
             </p>
           </div>

--- a/swift_browser_ui_frontend/src/components/ReplicateContainer.vue
+++ b/swift_browser_ui_frontend/src/components/ReplicateContainer.vue
@@ -7,11 +7,9 @@
       outlined
       disabled
       :inverted="inverted"
+      icon-left="content-copy"
     >
-      <b-icon
-        icon="content-copy"
-        size="is-small"
-      /> {{ $t('message.copy') }}
+      {{ $t('message.copy') }}
     </b-button>
     <b-button
       v-else
@@ -19,11 +17,9 @@
       outlined
       :inverted="inverted"
       disabled
+      icon-left="content-copy"
     >
-      <b-icon
-        icon="content-copy"
-        size="is-small"
-      /> {{ $t('message.copy') }}
+      {{ $t('message.copy') }}
     </b-button>
   </div>
   <div v-else>
@@ -33,6 +29,7 @@
       size="is-small"
       outlined
       :inverted="inverted"
+      icon-left="content-copy"
       @click="$router.push({
         name: 'ReplicateContainer',
         params: {
@@ -41,16 +38,14 @@
         }
       })"
     >
-      <b-icon
-        icon="content-copy"
-        size="is-small"
-      /> {{ $t('message.copy') }}
+      {{ $t('message.copy') }}
     </b-button>
     <b-button
       v-else
       type="is-primary"
       outlined
       :inverted="inverted"
+      icon-left="content-copy"
       @click="$router.push({
         name: 'ReplicateContainer',
         params: {
@@ -59,10 +54,7 @@
         }
       })"
     >
-      <b-icon
-        icon="content-copy"
-        size="is-small"
-      /> {{ $t('message.copy') }}
+      {{ $t('message.copy') }}
     </b-button>
   </div>
 </template>

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -159,11 +159,9 @@
                 size="is-small"
                 disabled
                 inverted
+                icon-left="share"
               >
-                <b-icon
-                  icon="share"
-                  size="is-small"
-                /> {{ $t('message.share.share') }}
+                {{ $t('message.share.share') }}
               </b-button>
               <b-button
                 v-else
@@ -171,11 +169,9 @@
                 outlined
                 size="is-small"
                 disabled
+                icon-left="share"
               >
-                <b-icon
-                  icon="share"
-                  size="is-small"
-                /> {{ $t('message.share.share') }}
+                {{ $t('message.share.share') }}
               </b-button>
             </p>
             <p
@@ -188,30 +184,26 @@
                 outlined
                 size="is-small"
                 inverted
+                icon-left="share"
                 @click="$router.push({
                   name: 'SharingView',
                   query: {container: props.row.name}
                 })"
               >
-                <b-icon
-                  icon="share"
-                  size="is-small"
-                /> {{ $t('message.share.share') }}
+                {{ $t('message.share.share') }}
               </b-button>
               <b-button
                 v-else
                 type="is-primary"
                 outlined
                 size="is-small"
+                icon-left="share"
                 @click="$router.push({
                   name: 'SharingView',
                   query: {container: props.row.name}
                 })"
               >
-                <b-icon
-                  icon="share"
-                  size="is-small"
-                /> {{ $t('message.share.share') }}
+                {{ $t('message.share.share') }}
               </b-button>
             </p>
             <p class="control">


### PR DESCRIPTION
### Description

Pass icons as props to buttons that didn't yet, so that they position better in relation to the button label. I think it looks better, but it does take up more horizontal space.

Before:
![image](https://user-images.githubusercontent.com/93575941/144563620-1711c574-af78-45c9-8f3c-79b4ae0e9acc.png)
After:
![image](https://user-images.githubusercontent.com/93575941/144563680-62488719-4d70-46ee-9a68-31a537351ee5.png)


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
