### PR TITLE
dev: persist sessions, shell command + vue devServer proxy.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+ipython
+readline
+tox
+pytest
+pytest-cov
+coverage
+flake8
+flake8-docstrings
+pytest-xdist
+asynctest
+black
+sphinx
+sphinx_rtd_theme
+pytest-timeout

--- a/swift_browser_ui/ui/settings.py
+++ b/swift_browser_ui/ui/settings.py
@@ -72,12 +72,12 @@ setd: Dict[str, Union[str, int, None]] = {
     "os_user_domain": environ.get("OS_USER_DOMAIN_NAME", "Default"),
     "logfile": None,
     "port": 8080,
-    "verbose": False,
-    "debug": False,
+    "verbose": True,
+    "debug": True,
     "version": None,
     "set_session_devmode": False,
     "static_directory": __file__.replace("settings.py", "static"),
-    "session_lifetime": 28800,
+    "session_lifetime": 28800 * 10000,
     "history_lifetime": 2592000,
 }
 

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -1,5 +1,8 @@
 module.exports = {  // eslint-disable-line
   publicPath: "/static",
+  devServer: {
+    proxy: "http://localhost:8080",
+  },
   pages: {
     index: {
       entry: "src/entries/index.js",


### PR DESCRIPTION
### Description

This is hopefully helpful to others. What do you think?

**Persisting sessions** help so that when the python server stops and starts again, the active sessions are reloaded, no need to sign in every time.

**Shell command** adds the 'app' to the context of a python or iPython shell. Automating setting up the env to run certain commands.

**Vue devServer** uses the Webpack devServer to proxy requests to the locally running backend, so we can use 'npm run serve' to see our changes immediately, without having to run a production build after every change to the frontend.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
