### PR TITLE
Add possibility to tag objects.

### DIFF
--- a/docs/_static/api.yml
+++ b/docs/_static/api.yml
@@ -718,6 +718,37 @@ paths:
           description: Unauthorized
         404:
           description: Not Found
+    post:
+      tags:
+        - Frontend
+      summary: Update user created container metadata.
+      parameters:
+        - name: container
+          in: query
+          description: The container which metadata will be updated.
+          schema:
+            type: string
+            example: test-container-1
+          required: true
+      requestBody:
+        description: Bucket metadata as a key-value object. Updates must include all the metadata for the bucket. Omitted keys are removed by the swift backend.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+              example:
+                owner: project-team
+      responses:
+        204:
+          description: Container metadata was updated. No Content.
+        403:
+          description: Unauthorized
+        404:
+          description: Container was not found
   /api/bucket/object/meta:
     get:
       tags:
@@ -750,34 +781,48 @@ paths:
     post:
       tags:
         - Frontend
-      summary: Update user created container metadata.
+      summary: Update user created object metadata.
       parameters:
         - name: container
           in: query
-          description: The container which metadata will be updated.
+          description: The container which contains the objects to be updated.
           schema:
             type: string
             example: test-container-1
           required: true
       requestBody:
-        description: Bucket metadata as a key-value object. Updates must include all the metadata for the bucket. Omitted keys are removed by the swift backend.
+        description: Object metadata as an array of tuples with the object name and a key-value object. Updates must include all the metadata for the object. Omitted keys are removed by the swift backend.
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                key:
-                  type: string
+              type: array
               example:
-                owner: project-team
+                - - object-name
+                  - key: value
+              items:
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: object
+                minItems: 2
+                maxItems: 2
+                example:
+                  - object-name
+                  - key: value
+            example:
+              - - object-name
+                - key: value
       responses:
         204:
-          description: Container metadata was updated. No Content.
+          description: Object metadata was updated. No Content.
+        400:
+          description: Payload malformed. Bad request.
         403:
-          description: Unauthorized
+          description: Unauthorized.
         404:
-          description: Container was not found
+          description: At least one object was not found.
   /api/shared/objects:
     get:
       tags:

--- a/swift_browser_ui/ui/server.py
+++ b/swift_browser_ui/ui/server.py
@@ -45,6 +45,7 @@ from swift_browser_ui.ui.api import (
     swift_check_object_chunk,
     swift_replicate_container,
     update_metadata_bucket,
+    update_metadata_object,
 )
 from swift_browser_ui.ui.health import handle_health_check
 from swift_browser_ui.ui.settings import setd
@@ -161,6 +162,7 @@ async def servinit() -> aiohttp.web.Application:
             aiohttp.web.get("/api/bucket/meta", get_metadata_bucket),
             aiohttp.web.post("/api/bucket/meta", update_metadata_bucket),
             aiohttp.web.get("/api/bucket/object/meta", get_metadata_object),
+            aiohttp.web.post("/api/bucket/object/meta", update_metadata_object),
             aiohttp.web.get("/api/project/meta", get_project_metadata),
             aiohttp.web.get("/api/project/acl", get_access_control_metadata),
             aiohttp.web.post("/api/access/{container}", add_project_container_acl),

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -1,6 +1,9 @@
 // API fetch functions.
 
-import { getHumanReadableSize } from "@/common/conv";
+import { 
+  getHumanReadableSize, 
+  makeGetObjectsMetaURL,
+} from "@/common/conv";
 
 export async function getUser() {
   // Function to get the username of the currently displayed user.
@@ -131,7 +134,42 @@ export async function getObjects(container) {
   return objects;
 }
 
-export async function getSharedObjects(
+export async function getObjectsMeta (
+  container,
+  objects,
+  url,
+){
+  if (url === undefined) {  
+    url = makeGetObjectsMetaURL(container, objects);
+  }
+
+  let ret = await fetch(
+    url, {method: "GET", credentials: "same-origin"},
+  );
+  return ret.json();
+}
+
+export async function updateObjectMeta (
+  container,
+  objectMeta,
+){
+  let url = new URL(
+    "/api/bucket/object/meta?container=".concat(encodeURI(container)),
+    document.location.origin,
+  );
+
+  let ret = await fetch(
+    url,
+    {
+      method: "POST",
+      credentials: "same-origin",
+      body: JSON.stringify([objectMeta]),
+    },
+  );
+  return ret;
+}
+
+export async function getSharedObjects (
   project,
   container,
   url,

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -192,6 +192,8 @@ let default_translations = {
       copysuccess: "Started copying the bucket in the background",
       copyfail: "Failed to copy the bucket",
       renderFolders: "Render as Folders",
+      tagName: "Tags",
+      tagMessage: "Press enter to add.",
       container_ops: {
         addContainer: "Add a new bucket",
         editContainer: "Editing bucket: ",
@@ -203,10 +205,10 @@ let default_translations = {
         containerMessage: "The name of the new bucket",
         fullDelete: "Deleting a bucket with contents requires deleting " +
                     "all objects inside it first.",
-        tagName: "Tags",
-        tagMessage: "Press enter to add.",
       },
       objects: {
+        objectName: "Object",
+        editObject: "Editing object: ",
         deleteConfirm: "Delete Objects",
         deleteObjects: "Delete Object / Objects",
         deleteSuccess: "Objects deleted",
@@ -422,6 +424,8 @@ let default_translations = {
       copysuccess: "Aloitettiin säiliön kopiointi taustalla",
       copyfail: "Säiliön kopiointi epäonnistui",
       renderFolders: "Näytä kansioina",
+      tagName: "Tägit",
+      tagMessage: "Paina 'enter' lisätäksesi.",
       container_ops: {
         addContainer: "Luo uusi säiliö",
         editContainer: "Muokataan säiliötä: ",
@@ -431,10 +435,10 @@ let default_translations = {
         containerName: "Säiliö",
         containerMessage: "Uuden säiliön nimi",
         fullDelete: "Säiliön sisältö on poistettava ennen säiliön postamista.",
-        tagName: "Tägit",
-        tagMessage: "Paina 'enter' lisätäksesi.",
       },
       objects: {
+        objectName: "Objekti",
+        editObject: "Muokataan objekti: ",
         deleteConfirm: "Poista objektit",
         deleteObjects: "Poista objekti / objektit",
         deleteSuccess: "Objektit poistettu",

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -3,6 +3,7 @@ import Router from "vue-router";
 import DashboardView from "@/views/Dashboard.vue";
 import ContainersView from "@/views/Containers.vue";
 import ObjectsView from "@/views/Objects.vue";
+import EditObjectView from "@/views/EditObject.vue";
 import SharedObjects from "@/views/SharedObjects";
 import ShareRequests from "@/views/ShareRequests";
 import SharedTo from "@/views/SharedTo";
@@ -88,6 +89,11 @@ export default new Router({
       path: "/browse/:user/:project/:container",
       name: "ObjectsView",
       component: ObjectsView,
+    },
+    {
+      path: "/browse/:user/:project/:container/:object/edit",
+      name: "EditObjectView",
+      component: EditObjectView,
     },
   ],
 });

--- a/swift_browser_ui_frontend/src/components/ObjectDeleteButton.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectDeleteButton.vue
@@ -53,10 +53,7 @@ export default {
         this.$route.params.container,
         to_remove,
       ).then(() => {
-        this.$store.commit({
-          type: "updateObjects",
-          route: this.$route,
-        });
+        this.$store.dispatch("updateObjects", this.$route);
       });
     },
   },

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -170,10 +170,7 @@ new Vue({
         type: "is-success",
       });
       if (this.$route.params.container != undefined) {
-        this.$store.commit({
-          type: "updateObjects",
-          route: this.$route,
-        });
+        this.$store.dispatch("updateObjects", this.$route);
       }
     },
     fileFailureToast: function (file) {

--- a/swift_browser_ui_frontend/src/views/AddContainer.vue
+++ b/swift_browser_ui_frontend/src/views/AddContainer.vue
@@ -25,8 +25,8 @@
     </b-field>
     <b-field
       horizontal
-      :label="$t('message.container_ops.tagName')"
-      :message="$t('message.container_ops.tagMessage')"
+      :label="$t('message.tagName')"
+      :message="$t('message.tagMessage')"
     >
       <b-taginput
         v-model="tags"
@@ -63,6 +63,7 @@ import {
   updateBucketMeta,
 } from "@/common/api";
 import {
+  taginputConfirmKeys,
   getTagsForContainer,
 } from "@/common/conv";
 
@@ -73,7 +74,7 @@ export default {
       container: "",
       tags: [],
       create: true,
-      taginputConfirmKeys: [",", ";", ":", ".", " ", "Tab", "Enter"],
+      taginputConfirmKeys,
     };
   },
   beforeMount () {

--- a/swift_browser_ui_frontend/src/views/EditObject.vue
+++ b/swift_browser_ui_frontend/src/views/EditObject.vue
@@ -1,0 +1,119 @@
+<template>
+  <div 
+    id="editObject"
+    class="contents"
+  >
+    <h1 class="title is-3">
+      {{ $t('message.objects.editObject') + object }}
+    </h1>
+    <b-field
+      horizontal
+      :label="$t('message.objects.objectName')"
+    >
+      <b-input 
+        v-model="object"
+        name="object"
+        expanded
+        aria-required="true"
+        disabled
+      />
+    </b-field>
+    <b-field
+      horizontal
+      :label="$t('message.tagName')"
+      :message="$t('message.tagMessage')"
+    >
+      <b-taginput
+        v-model="tags"
+        ellipsis
+        maxlength="20"
+        icon="label"
+        has-counter
+        rounded
+        type="is-primary"
+        :confirm-keys="taginputConfirmKeys"
+        :on-paste-separators="taginputConfirmKeys"
+      />
+    </b-field>
+
+    <b-field
+      horizontal
+    >
+      <p class="control">
+        <b-button
+          type="is-primary"
+          class="editObjectButton"
+          @click="updateObject ()"
+        >
+          {{ $t('message.save') }}
+        </b-button>
+      </p>
+    </b-field>
+  </div>
+</template>
+
+<script>
+import {
+  updateObjectMeta,
+} from "@/common/api";
+import {
+  taginputConfirmKeys,
+  getTagsForObjects,
+} from "@/common/conv";
+
+export default {
+  name: "EditObjectView",
+  data () {
+    return {
+      container: "",
+      object: "",
+      tags: [],
+      taginputConfirmKeys,
+    };
+  },
+  beforeMount () {
+    this.getObject();
+  },
+  methods: {
+    getObject: async function () {
+      const containerName = this.$route.params.container;
+      const objectName = this.$route.params.object;
+      this.container = containerName;
+      this.object = objectName;
+
+      const tags = this.$store.state.objectTagsCache[objectName];
+      if (!tags) {
+        const tags = await getTagsForObjects(containerName, [objectName]);
+        this.tags = tags[0][1] || [];
+      } else {
+        this.tags = tags;
+      }
+    },
+    updateObject: function () {
+      let objectMeta = [
+        this.object,
+        {
+          usertags: this.tags.join(";"),
+        },
+      ];
+      updateObjectMeta(this.container, objectMeta).then(() => {
+        this.$router.go(-1);
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+  #editObject {
+    width: auto;
+    margin-left: 5%;
+    margin-right: 5%;
+  }
+  hi.title {
+    margin: 1% 1% 1% 0;
+  }
+  .editObjectButton {
+    margin: 1%;
+  }
+</style>

--- a/tests/cypress/integration/browser.spec.js
+++ b/tests/cypress/integration/browser.spec.js
@@ -38,7 +38,7 @@ describe("Browse buckets and test operations", function () {
         .within(() => {
           cy.get('td').eq(0).click()
           cy.get('td').eq(1).then(($elem) => {
-            expect($elem.get(0).innerText.trim()).to.have.lengthOf(40)
+            expect($elem.get(0).innerText.split('\n')[0].trim()).to.have.lengthOf(40)
           })
         })
     })
@@ -64,19 +64,19 @@ describe("Browse buckets and test operations", function () {
 
   })
 
-  it("should display, add, remove tags", () => {
+  it("should display, add, remove container tags", () => {
     // container list loads with tags
     cy.get('tbody .tags .tag').should('have.length', 40)
     cy.get('tbody tr .tags').first().children('.tag').should('have.length', 4)
     
-    // // remove one tag
+    // remove one tag
     cy.get('tbody tr').contains('Edit').click()
     cy.get('h1').should('contain', 'Editing bucket')
     cy.get('.delete').first().click()
     cy.get('button').contains('Save').click()
     cy.get('tbody tr .tags').first().children('.tag').should('have.length', 3)
 
-    // // add few tags
+    // add few tags
     cy.get('tbody tr').contains('Edit').click()
     cy.get('.taginput input').type('adding.couple more')
     cy.get('button').contains('Save').click()
@@ -87,10 +87,39 @@ describe("Browse buckets and test operations", function () {
     cy.get('.taginput-container').children('span').should('have.length', 6)
     cy.get('.delete').each(el => {
       cy.get('.delete').first().click()
-      cy.wait(100)
     });
     cy.get('.taginput-container').children('span').should('have.length', 0)
     cy.get('button').contains('Save').click()
     cy.get('tbody .tags .tag').should('have.length', 36)
+  })
+
+  it("should display, add, remove object tags", () => {
+    cy.get('tbody tr').first().dblclick()
+
+    // object list loads with tags
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 3)
+    
+    // remove one tag
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('h1').should('contain', 'Editing object')
+    cy.get('.delete').first().click()
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 2)
+
+    // add few tags
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('.taginput input').type('adding.couple more')
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 5)
+
+    // remove all tags from an object
+    cy.get('tbody tr').contains('Edit').click()
+    cy.get('.taginput-container').children('span').should('have.length', 5)
+    cy.get('.delete').each(el => {
+      cy.get('.delete').first().click()
+    });
+    cy.get('.taginput-container').children('span').should('have.length', 0)
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 0)
   })
 })


### PR DESCRIPTION
### Description

This is a continuation to the tagging buckets feature from PR #419. The implementation is very similar.

The openApi spec supports tuples in 3.1 with `prefixItems`. We may want to change the api docs when that comes into use.

It does only one request to fetch metadata for all objects in a bucket.

**NB:** Please, check the Finnish language :)

### Related issues
Is #5 solved with this?

- #427

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

Added backend for updating metadata for an object. Added UI for displaying tags for objects, as well as hiding them. There is a new button, called 'Edit', which makes it possible to edit an object's tags. 

![image](https://user-images.githubusercontent.com/93575941/145353830-06ed9fed-286e-470c-8758-690709c54952.png)
![image](https://user-images.githubusercontent.com/93575941/145354305-3f4f5b9b-dc5f-4f2b-911c-047da1242318.png)


Previously, the api docs for container update metadata had gone to the wrong place. The fix is in this PR :)

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
