### PR TITLE
dev: devServer proxy, VSCode hints. 

### DIFF
--- a/swift_browser_ui_frontend/README.md
+++ b/swift_browser_ui_frontend/README.md
@@ -6,6 +6,8 @@ npm install
 ```
 
 ### Compiles and hot-reloads for development
+This command also proxies the backend requests to a locally running server, by default `http://localhost:8080`.
+You can specify the host and port with `BACKEND_HOST` and `BACKEND_PORT`, respectively.
 ```
 npm run serve
 ```
@@ -15,15 +17,10 @@ npm run serve
 npm run build
 ```
 
-### Run your tests
-```
-npm run test
-```
-
 ### Lints and fixes files
 ```
 npm run lint
 ```
 
 ### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+See [Vue.js Configuration Reference](https://cli.vuejs.org/config/).

--- a/swift_browser_ui_frontend/jsconfig.json
+++ b/swift_browser_ui_frontend/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "es6",
+    "target": "es6",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"],
+  "allowSyntheticDefaultImports": true
+}

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -1,5 +1,10 @@
 module.exports = {  // eslint-disable-line
   publicPath: "/static",
+  devServer: {
+    // eslint-disable-next-line
+    proxy: `${process.env.BACKEND_HOST || "http://localhost"}:${process.env.BACKEND_PORT || "8080"}`,
+    hot: true,
+  },
   pages: {
     index: {
       entry: "src/entries/index.js",

--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,12 @@
+// This file configures the VSCode Vetur extension, which adds support for Vue.js to VSCode.
+module.exports = {
+settings: {
+  "vetur.useWorkspaceDependencies": true,
+  "vetur.experimental.templateInterpolationService": true,
+},
+projects: [
+    {
+      root: './swift_browser_ui_frontend',
+    },
+  ],
+}


### PR DESCRIPTION
### Description

- Uses the Webpack `devServer` to proxy requests to the locally running backend, so we can use `npm run serve` to see our changes immediately, without having to run a production build after every change to the frontend.
- Proper VSCode + Vetur hints with `jsconfig.json` and `vetur.config.js`.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
- Proxy the development frontend server to a locally running backend.
- `jsconfig.json` makes VSCode find code references and imports.
- `vetur.config.js` makes Vetur find the frontend code, as we use a monorepo.
- We actually don't have `npm run test`, so I removed it from the README.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
