### PR TITLE
Bugfix for shared objects not loading.

### DIFF
--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -149,11 +149,11 @@ const store = new Vuex.Store({
         );
       });
     },
-    updateObjects: async function ({ commit, dispatch, client }, route) {
+    updateObjects: async function ({ commit, dispatch, state }, route) {
       let container = route.params.container;
       commit("loading", true);
       if (route.name == "SharedObjects") {
-        await client.getAccessDetails(
+        await state.client.getAccessDetails(
           route.params.project,
           container,
           route.params.owner,

--- a/swift_browser_ui_frontend/src/components/SharedTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedTable.vue
@@ -160,11 +160,14 @@ export default {
       }
     },
     getConAddr: function (row) {
-      return "/browse/shared/".concat(
-        this.$route.params.project,
-        "/", row.owner,
-        "/", row.container,
-      );
+      return {
+        name: "SharedObjects",
+        params: {
+          project: this.$route.params.project,
+          owner: row.owner,
+          container: row.container,
+        },
+      };
     },
   },
 };


### PR DESCRIPTION
### Description

This was introduced in the breadcrumbs commit #418, which changed routes, so it affects production as well.
The second issue, with wrong reference for `client` was introduced with the objects tagging feature #426.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Proper reference for `client`.
- Build the route through vuex route options instead of manually creating url. That fixed the routing issue.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
