### PR TITLE
Abort large number of fetch requests

### DIFF
--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -77,6 +77,7 @@ export async function getBuckets() {
 
 export async function getBucketMeta(
   container,
+  signal,
 ){
   let url = new URL(
     "/api/bucket/meta?container=".concat(encodeURI(container)),
@@ -84,7 +85,7 @@ export async function getBucketMeta(
   );
 
   let ret = await fetch(
-    url, {method: "GET", credentials: "same-origin"},
+    url, {method: "GET", credentials: "same-origin", signal},
   );
   return ret.json();
 }
@@ -109,7 +110,7 @@ export async function updateBucketMeta(
   return ret;
 }
 
-export async function getObjects(container) {
+export async function getObjects(container, signal) {
   // Fetch objects contained in a container from the API for the user
   // that's currently logged in.
   let objUrl = new URL("/api/bucket/objects", document.location.origin);
@@ -117,7 +118,7 @@ export async function getObjects(container) {
   // over from S3 to Swift
   objUrl.searchParams.append("bucket", container);
   let objects = fetch(
-    objUrl, { method: "GET", credentials: "same-origin" },
+    objUrl, { method: "GET", credentials: "same-origin", signal },
   ).then(
     function (resp) { return resp.json(); },
   ).then(
@@ -138,13 +139,14 @@ export async function getObjectsMeta (
   container,
   objects,
   url,
+  signal,
 ){
   if (url === undefined) {  
     url = makeGetObjectsMetaURL(container, objects);
   }
 
   let ret = await fetch(
-    url, {method: "GET", credentials: "same-origin"},
+    url, {method: "GET", credentials: "same-origin", signal},
   );
   return ret.json();
 }

--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -162,13 +162,18 @@ function extractTags(meta) {
   return [];
 }
 
-export async function getTagsForContainer(containerName) {
-  let meta = await getBucketMeta(containerName);
+export async function getTagsForContainer(containerName, signal) {
+  let meta = await getBucketMeta(containerName, signal);
   return extractTags(meta);
 }
 
-export async function getTagsForObjects(containerName, objectList, url) {
-  let meta = await getObjectsMeta(containerName, objectList, url);
+export async function getTagsForObjects(
+  containerName, 
+  objectList, 
+  url, 
+  signal,
+) {
+  let meta = await getObjectsMeta(containerName, objectList, url, signal);
   meta.map(item => item[1] = extractTags(item));
   return meta;
 }

--- a/swift_browser_ui_frontend/src/components/ObjectDeleteButton.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectDeleteButton.vue
@@ -53,7 +53,7 @@ export default {
         this.$route.params.container,
         to_remove,
       ).then(() => {
-        this.$store.dispatch("updateObjects", this.$route);
+        this.$store.dispatch("updateObjects", {route: this.$route});
       });
     },
   },

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -362,6 +362,7 @@ export default {
       searchQuery: "",
       currentPage: 1,
       checkedRows: [],
+      abortController: null,
     };
   },
   computed: {
@@ -419,16 +420,23 @@ export default {
     this.debounceFilter = debounce(this.filter, 400);
   },
   beforeMount () {
+    this.abortController = new AbortController();
     this.getDirectCurrentPage();
     this.checkLargeDownloads();
   },
   mounted () {
     this.updateObjects();
   },
+  beforeDestroy () {
+    this.abortController.abort();
+  },
   methods: {
     updateObjects: function () {
       // Update current object listing in Vuex if length is too little
-      this.$store.dispatch("updateObjects", this.$route);
+      this.$store.dispatch(
+        "updateObjects", 
+        {route: this.$route, signal: this.abortController.signal},
+      );
     },
     isRowCheckable: function (row) {
       return this.renderFolders ? this.isFile(row.name) : true;

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -170,7 +170,7 @@ new Vue({
         type: "is-success",
       });
       if (this.$route.params.container != undefined) {
-        this.$store.dispatch("updateObjects", this.$route);
+        this.$store.dispatch("updateObjects", {route: this.$route});
       }
     },
     fileFailureToast: function (file) {

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -317,6 +317,7 @@ export default {
       currentPage: 1,
       shareModalIsActive: false,
       showTags: true,
+      abortController: null,
     };
   },
   computed: {
@@ -348,17 +349,24 @@ export default {
     this.debounceFilter = debounce(this.filter, 400);
   },
   beforeMount () {
+    this.abortController = new AbortController();
     this.getDirectCurrentPage();
   },
   mounted() {
     this.fetchContainers();
+  },
+  beforeDestroy () {
+    this.abortController.abort();
   },
   methods: {
     fetchContainers: async function () {
       // Get the container listing from the API if the listing hasn't yet
       // been cached.
       if(this.bList.length < 1) {
-        await this.$store.dispatch("updateContainers");
+        await this.$store.dispatch(
+          "updateContainers", 
+          this.abortController.signal,
+        );
       }
     },
     checkPageFromRoute: function () {


### PR DESCRIPTION
### Description

Loading tags is unnecessary when navigating to another page, and it
keeps browser resources busy. This change cancels those requests when
browsing away.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality

### Changes Made

Container and object view can cancel loading of tags when moving away of the page using an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController). 

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
