### PR TITLE
Inform that container and objects can't be renamed.

### DIFF
--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -197,6 +197,8 @@ let default_translations = {
       container_ops: {
         addContainer: "Add a new bucket",
         editContainer: "Editing bucket: ",
+        norename: "It is not possible to rename buckets. " +
+        "However, you can copy them with a new name.",
         deleteConfirm: "Delete Bucket",
         deleteConfirmMessage: "Are you sure you want to delete this " +
                               "bucket?",
@@ -209,6 +211,8 @@ let default_translations = {
       objects: {
         objectName: "Object",
         editObject: "Editing object: ",
+        norename: "It is not possible to rename objects. " +
+        "However, you can copy them with a new name.",
         deleteConfirm: "Delete Objects",
         deleteObjects: "Delete Object / Objects",
         deleteSuccess: "Objects deleted",
@@ -429,6 +433,8 @@ let default_translations = {
       container_ops: {
         addContainer: "Luo uusi säiliö",
         editContainer: "Muokataan säiliötä: ",
+        norename: "Säiliötä ei voi nimetä uudelleen, " +
+        "mutta sen voi kopioida uudella nimellä.",
         deleteConfirm: "Poista säiliö",
         deleteConfirmMessage: "Haluatko varmasti poistaa tämän säiliön?",
         deleteSuccess: "Säiliö poistettu",
@@ -439,6 +445,8 @@ let default_translations = {
       objects: {
         objectName: "Objekti",
         editObject: "Muokataan objekti: ",
+        norename: "Objektia ei voi nimetä uudelleen, " +
+        "mutta sen voi kopioida uudella nimellä.",
         deleteConfirm: "Poista objektit",
         deleteObjects: "Poista objekti / objektit",
         deleteSuccess: "Objektit poistettu",

--- a/swift_browser_ui_frontend/src/views/AddContainer.vue
+++ b/swift_browser_ui_frontend/src/views/AddContainer.vue
@@ -10,6 +10,9 @@
           : $t('message.container_ops.editContainer') + container
       }}
     </h1>
+    <b-message type="is-info">
+      {{ $t('message.container_ops.norename') }}
+    </b-message>
     <b-field
       horizontal
       :label="$t('message.container_ops.containerName')"

--- a/swift_browser_ui_frontend/src/views/EditObject.vue
+++ b/swift_browser_ui_frontend/src/views/EditObject.vue
@@ -6,6 +6,9 @@
     <h1 class="title is-3">
       {{ $t('message.objects.editObject') + object }}
     </h1>
+    <b-message type="is-info">
+      {{ $t('message.objects.norename') }}
+    </b-message>
     <b-field
       horizontal
       :label="$t('message.objects.objectName')"


### PR DESCRIPTION
### Description

Shows a meassage saying that container and objects can't be renamed. The tag featured introduced an edit view for container and objects, which may lead to the impression that somehow container and object names could be edited. This message tries to clarify that they can't.

@sampsapenna, please check the Finnish words. :)


![image](https://user-images.githubusercontent.com/93575941/147124589-69c3c678-8259-49be-8f24-bfc59c677593.png)

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
