### PR TITLE
don't change state after application started

### DIFF
--- a/swift_browser_ui/request/server.py
+++ b/swift_browser_ui/request/server.py
@@ -33,6 +33,8 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 async def resume_on_start(app: aiohttp.web.Application) -> None:
     """Resume old instance on start."""
+    app["db_conn"] = DBConn()
+    app["tokens"] = []
     await app["db_conn"].open()
 
 
@@ -52,9 +54,6 @@ async def init_server() -> aiohttp.web.Application:
             swift_browser_ui.common.common_middleware.catch_uniqueness_error,  # type: ignore
         ]
     )
-
-    app["db_conn"] = DBConn()
-    app["tokens"] = []
 
     app.add_routes(
         [

--- a/swift_browser_ui/sharing/server.py
+++ b/swift_browser_ui/sharing/server.py
@@ -38,6 +38,7 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 async def resume_on_start(app: aiohttp.web.Application) -> None:
     """Resume old instance from start."""
+    app["db_conn"] = DBConn()
     await app["db_conn"].open()
 
 
@@ -57,8 +58,6 @@ async def init_server() -> aiohttp.web.Application:
             swift_browser_ui.common.common_middleware.catch_uniqueness_error,  # type:ignore
         ]
     )
-
-    app["db_conn"] = DBConn()
 
     app.add_routes(
         [

--- a/tests/request/test_server.py
+++ b/tests/request/test_server.py
@@ -1,7 +1,6 @@
 """Module for testing server.py."""
 
 
-from types import SimpleNamespace
 import unittest.mock
 
 
@@ -10,45 +9,19 @@ import aiohttp
 
 
 from swift_browser_ui.request.server import (
-    resume_on_start,
-    graceful_shutdown,
     init_server,
     run_server_devel,
     main,
 )
-from swift_browser_ui.request.db import DBConn
 
 
 class ServerTestCase(asynctest.TestCase):
     """Test case for testing server module functions."""
 
-    def setUp(self):
-        """Set up relevant mocks."""
-        self.mock_db_conn = SimpleNamespace(
-            **{
-                "open": asynctest.CoroutineMock(),
-                "close": asynctest.CoroutineMock(),
-            }
-        )
-
-        self.mock_application = {"db_conn": self.mock_db_conn}
-
-    async def test_resume_on_start(self):
-        """Test resume on start function."""
-        await resume_on_start(self.mock_application)
-        self.mock_db_conn.open.assert_awaited_once()
-
-    async def test_graceful_shutdown(self):
-        """Test graceful shutdown function."""
-        await graceful_shutdown(self.mock_application)
-        self.mock_db_conn.close.assert_awaited_once()
-
     async def test_init_server(self):
         """Test init_server function."""
         app = await init_server()
         self.assertIsInstance(app, aiohttp.web.Application)
-        self.assertIsInstance(app["db_conn"], DBConn)
-        self.assertIsNotNone(app["tokens"])
 
     async def test_run_server_devel(self):
         """Test server development mode launch function."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38}, flake8, bandit, pytest, docs, mypy, black
+envlist = flake8, bandit, pytest, docs, mypy, black
 skipdist = True
 
 [flake8]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
corresponds to: https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web_app.py#L146 and https://docs.aiohttp.org/en/stable/web_advanced.html#background-tasks

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. changing state after application is not possible any more adding the states to `on_startup` for the `web.Application`
2. adjust unit tests
3. remove tox envs that are not used for py37 and py38

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
Pending Testing ... to see if it behaves as it should