### PR TITLE
remove asynctest & unittest_run_loop as deprecated

### DIFF
--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -34,7 +34,6 @@ writing the tests:
 
 * `tox for test automation <https://tox.readthedocs.io/en/latest/>`_
 * `cypress for UI test automation <https://www.cypress.io/>`_
-* `asynctest for implementing async testing with TestCase class <https://asynctest.readthedocs.io/en/latest/>`_
 * `pytest-timeout for timing out UI tests, which can hang when failing <https://pypi.org/project/pytest-timeout/1.2.1/>`_
 
 UI tests also require the WebDrivers for Chrome and Firefox, if tests are to

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
             "flake8==4.0.1",
             "flake8-docstrings==1.6.0",
             "pytest-xdist==2.5.0",
-            "asynctest==0.13.0",
             "black== 21.12b0",
         ],
         "docs": ["sphinx==4.3.2", "sphinx_rtd_theme==1.0.0"],

--- a/tests/common/test_common_handlers.py
+++ b/tests/common/test_common_handlers.py
@@ -1,13 +1,13 @@
 """Module for testing common handlers."""
 
 
-import asynctest
+import unittest
 import aiohttp
 
 import swift_browser_ui.common.common_handlers
 
 
-class PreflightHandlerTestCase(asynctest.TestCase):
+class PreflightHandlerTestCase(unittest.IsolatedAsyncioTestCase):
     """Preflight handler test case."""
 
     async def test_handle_delete_preflight(self):

--- a/tests/common/test_common_middleware.py
+++ b/tests/common/test_common_middleware.py
@@ -2,9 +2,7 @@
 
 
 import types
-import unittest.mock
-
-import asynctest
+import unittest
 import aiohttp.web
 
 import asyncpg.exceptions
@@ -12,7 +10,7 @@ import asyncpg.exceptions
 import swift_browser_ui.common.common_middleware as middle
 
 
-class CommonMiddlewareTestCase(asynctest.TestCase):
+class CommonMiddlewareTestCase(unittest.IsolatedAsyncioTestCase):
     """Common midleware unit test class"""
 
     def setUp(self):
@@ -24,7 +22,7 @@ class CommonMiddlewareTestCase(asynctest.TestCase):
             }
         )
         self.app_mock = {}
-        self.mock_handler = asynctest.CoroutineMock(return_value=aiohttp.web.Response())
+        self.mock_handler = unittest.mock.AsyncMock(return_value=aiohttp.web.Response())
         super().setUp()
 
     async def test_add_cors(self):
@@ -55,7 +53,7 @@ class CommonMiddlewareTestCase(asynctest.TestCase):
 
     async def test_catch_uniqueness_error(self):
         """Test uniqueness error catch middleware."""
-        unique_violating_handler = asynctest.CoroutineMock(
+        unique_violating_handler = unittest.mock.AsyncMock(
             side_effect=asyncpg.exceptions.UniqueViolationError
         )
         with self.assertRaises(aiohttp.web.HTTPConflict):
@@ -64,21 +62,21 @@ class CommonMiddlewareTestCase(asynctest.TestCase):
             )
 
 
-class HandleValidateAuthTest(asynctest.TestCase):
+class HandleValidateAuthTest(unittest.IsolatedAsyncioTestCase):
     """Auth middleware tests."""
 
     async def test_handle_validate_authentication_success(self):
         """Test authentication validation handler success."""
-        t_singature_mock = asynctest.CoroutineMock()
+        t_singature_mock = unittest.mock.AsyncMock()
         t_signature_patch = unittest.mock.patch(
             "swift_browser_ui.common.signature.test_signature", t_singature_mock
         )
 
-        get_tokens_mock = asynctest.CoroutineMock(
+        get_tokens_mock = unittest.mock.AsyncMock(
             return_value=[{"token": "example-token"}]
         )
 
-        handler_mock = asynctest.CoroutineMock()
+        handler_mock = unittest.mock.AsyncMock()
         request_mock = types.SimpleNamespace(
             **{
                 "app": {
@@ -98,7 +96,7 @@ class HandleValidateAuthTest(asynctest.TestCase):
 
     async def test_handle_validate_authentication_failure(self):
         """Test authentication validation handler failure."""
-        handler_mock = asynctest.CoroutineMock()
+        handler_mock = unittest.mock.AsyncMock()
         request_mock = types.SimpleNamespace(
             **{
                 "query": {"signature": "a", "vali": "b"},
@@ -112,7 +110,7 @@ class HandleValidateAuthTest(asynctest.TestCase):
 
     async def test_handle_validate_authentication_health(self):
         """Test authentication validation handler upon health check."""
-        handler_mock = asynctest.CoroutineMock()
+        handler_mock = unittest.mock.AsyncMock()
         request_mock = types.SimpleNamespace(
             **{
                 "path": "/health",

--- a/tests/common/test_common_signature.py
+++ b/tests/common/test_common_signature.py
@@ -1,17 +1,16 @@
 """Module for testing singatures in bindings module."""
 
 
-import unittest.mock
 import hmac
 import time
 
-import asynctest
+import unittest
 import aiohttp.web
 
 import swift_browser_ui.common.signature
 
 
-class SignatureModuleTestCase(asynctest.TestCase):
+class SignatureModuleTestCase(unittest.IsolatedAsyncioTestCase):
     """Test case for signature related methods."""
 
     def setUp(self):

--- a/tests/common/test_common_util.py
+++ b/tests/common/test_common_util.py
@@ -3,13 +3,11 @@
 
 import unittest
 
-import asynctest
-
 
 import swift_browser_ui.common.common_util
 
 
-class CommonUtilTestCase(asynctest.TestCase):
+class CommonUtilTestCase(unittest.IsolatedAsyncioTestCase):
     """Clkass for testing common utility functions."""
 
     def setUp(self):

--- a/tests/request/test_api.py
+++ b/tests/request/test_api.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 
 import aiohttp
-import asynctest
 
 
 from swift_browser_ui.request.api import (
@@ -18,7 +17,7 @@ from swift_browser_ui.request.api import (
 )
 
 
-class APITestClass(asynctest.TestCase):
+class APITestClass(unittest.IsolatedAsyncioTestCase):
     """Test class for testing API functions."""
 
     def setUp(self):
@@ -28,11 +27,11 @@ class APITestClass(asynctest.TestCase):
                 "app": {
                     "db_conn": SimpleNamespace(
                         **{
-                            "add_request": asynctest.mock.CoroutineMock(),
-                            "get_request_owned": asynctest.mock.CoroutineMock(),
-                            "get_request_made": asynctest.mock.CoroutineMock(),
-                            "get_request_container": asynctest.mock.CoroutineMock(),
-                            "delete_request": asynctest.mock.CoroutineMock(),
+                            "add_request": unittest.mock.AsyncMock(),
+                            "get_request_owned": unittest.mock.AsyncMock(),
+                            "get_request_made": unittest.mock.AsyncMock(),
+                            "get_request_container": unittest.mock.AsyncMock(),
+                            "delete_request": unittest.mock.AsyncMock(),
                         }
                     )
                 },

--- a/tests/request/test_bindings_bind.py
+++ b/tests/request/test_bindings_bind.py
@@ -1,23 +1,20 @@
 """Module for testing the bindings module / class."""
 
 
-import unittest.mock
+import unittest
 from types import SimpleNamespace
-
-
-import asynctest
 
 
 from swift_browser_ui.request.bindings.bind import SwiftSharingRequest
 
 
-class MockRequestContextManager(asynctest.TestCase):
+class MockRequestContextManager(unittest.IsolatedAsyncioTestCase):
     """Mock class for aiohttp request context manager."""
 
     def __init__(self, *args, **kwargs):
         """."""
         self.resp = SimpleNamespace(
-            **{"text": asynctest.CoroutineMock(return_value="[]"), "status": 200}
+            **{"text": unittest.mock.AsyncMock(return_value="[]"), "status": 200}
         )
 
     async def __aenter__(self, *args, **kwargs):
@@ -51,14 +48,14 @@ class MockDeleteContextManager(MockRequestContextManager):
         """."""
 
 
-class BindingsClassTestCase(asynctest.TestCase):
+class BindingsClassTestCase(unittest.IsolatedAsyncioTestCase):
     """Bindings class test case."""
 
     def setUp(self):
         """Set up relevant mocks."""
         self.session_mock = SimpleNamespace(
             **{
-                "close": asynctest.CoroutineMock(),
+                "close": unittest.mock.AsyncMock(),
                 "get": MockGenericContextManager,
                 "post": MockGenericContextManager,
                 "delete": MockDeleteContextManager,

--- a/tests/request/test_db.py
+++ b/tests/request/test_db.py
@@ -5,28 +5,25 @@ import datetime
 import unittest
 from types import SimpleNamespace
 
-
-import asynctest
-import asynctest.mock
 import asyncpg
 
 
 from swift_browser_ui.request.db import DBConn
 
 
-class DBConnTestClass(asynctest.TestCase):
+class DBConnTestClass(unittest.IsolatedAsyncioTestCase):
     """Test database connection class code."""
 
     def setUp(self):
         """Set up necessary mocks."""
         self.asyncpg_pool_mock = SimpleNamespace(
             **{
-                "close": asynctest.mock.CoroutineMock(),
+                "close": unittest.mock.AsyncMock(),
                 "terminate": unittest.mock.Mock(),
             }
         )
 
-        self.asyncpg_pool_mock = asynctest.CoroutineMock(
+        self.asyncpg_pool_mock = unittest.mock.AsyncMock(
             return_value=self.asyncpg_pool_mock,
         )
         self.patch_asyncpg_pool = unittest.mock.patch(
@@ -34,7 +31,7 @@ class DBConnTestClass(asynctest.TestCase):
             new=self.asyncpg_pool_mock,
         )
 
-        self.asyncpg_connect_mock_connection_error = asynctest.CoroutineMock(
+        self.asyncpg_connect_mock_connection_error = unittest.mock.AsyncMock(
             side_effect=ConnectionError
         )
         self.patch_asyncpg_pool_connection_error = unittest.mock.patch(
@@ -42,7 +39,7 @@ class DBConnTestClass(asynctest.TestCase):
             new=self.asyncpg_connect_mock_connection_error,
         )
 
-        self.asyncpg_connect_mock_invalid_pwd = asynctest.CoroutineMock(
+        self.asyncpg_connect_mock_invalid_pwd = unittest.mock.AsyncMock(
             side_effect=asyncpg.InvalidPasswordError("Invalid")
         )
         self.patch_asyncpg_pool_invalid_password = unittest.mock.patch(
@@ -55,7 +52,7 @@ class DBConnTestClass(asynctest.TestCase):
             "swift_browser_ui.request.db.os.environ.get", new=self.os_environ_mock
         )
 
-        self.asyncio_sleep_mock = asynctest.CoroutineMock(side_effect=Exception)
+        self.asyncio_sleep_mock = unittest.mock.AsyncMock(side_effect=Exception)
         self.patch_asyncio_sleep = unittest.mock.patch(
             "swift_browser_ui.request.db.asyncio.sleep", new=self.asyncio_sleep_mock
         )
@@ -64,7 +61,7 @@ class DBConnTestClass(asynctest.TestCase):
 
     def test_db_erase(self):
         """Test connection erase method."""
-        mock_terminate = asynctest.mock.CoroutineMock()
+        mock_terminate = unittest.mock.Mock()
         self.db.pool = SimpleNamespace(**{"terminate": mock_terminate})
         self.db.erase()
         mock_terminate.assert_called_once()
@@ -104,17 +101,17 @@ class DBConnTestClass(asynctest.TestCase):
             self.db.pool.close.assert_awaited_once()
 
 
-class DBMethodTestCase(asynctest.TestCase):
+class DBMethodTestCase(unittest.IsolatedAsyncioTestCase):
     """Test database query methods."""
 
     def setUp(self):
         """Set up required mocks."""
-        self.connection_transaction_mock = asynctest.MagicMock(
+        self.connection_transaction_mock = unittest.mock.MagicMock(
             asyncpg.Connection.transaction
         )
 
         class AsyncpgConnectionMock:
-            fetch = asynctest.CoroutineMock(
+            fetch = unittest.mock.AsyncMock(
                 return_value=[
                     {
                         "container": "test-container",
@@ -124,7 +121,7 @@ class DBMethodTestCase(asynctest.TestCase):
                     }
                 ]
             )
-            fetchrow = asynctest.CoroutineMock(
+            fetchrow = unittest.mock.AsyncMock(
                 return_value={
                     "container": "test-container",
                     "container_owner": "test-owner",
@@ -132,7 +129,7 @@ class DBMethodTestCase(asynctest.TestCase):
                     "created": datetime.datetime(2017, 1, 1),
                 }
             )
-            execute = asynctest.CoroutineMock()
+            execute = unittest.mock.AsyncMock()
             transaction = self.connection_transaction_mock
 
             def __init__(self):
@@ -149,7 +146,7 @@ class DBMethodTestCase(asynctest.TestCase):
 
         self.asyncpg_pool_mock = SimpleNamespace(
             **{
-                "fetch": asynctest.CoroutineMock(
+                "fetch": unittest.mock.AsyncMock(
                     return_value=[
                         {
                             "container": "test-container",
@@ -159,7 +156,7 @@ class DBMethodTestCase(asynctest.TestCase):
                         }
                     ]
                 ),
-                "fetchrow": asynctest.CoroutineMock(
+                "fetchrow": unittest.mock.AsyncMock(
                     return_value={
                         "container": "test-container",
                         "container_owner": "test-owner",

--- a/tests/request/test_server.py
+++ b/tests/request/test_server.py
@@ -1,10 +1,7 @@
 """Module for testing server.py."""
 
 
-import unittest.mock
-
-
-import asynctest
+import unittest
 import aiohttp
 
 
@@ -15,7 +12,7 @@ from swift_browser_ui.request.server import (
 )
 
 
-class ServerTestCase(asynctest.TestCase):
+class ServerTestCase(unittest.IsolatedAsyncioTestCase):
     """Test case for testing server module functions."""
 
     async def test_init_server(self):

--- a/tests/sharing/test_api.py
+++ b/tests/sharing/test_api.py
@@ -4,8 +4,7 @@
 from types import SimpleNamespace
 
 
-import unittest.mock
-import asynctest
+import unittest
 import aiohttp.web
 
 
@@ -21,7 +20,7 @@ from swift_browser_ui.sharing.api import (
 )
 
 
-class APITestClass(asynctest.TestCase):
+class APITestClass(unittest.IsolatedAsyncioTestCase):
     """Test the sharing backend public API."""
 
     def setUp(self):
@@ -31,14 +30,14 @@ class APITestClass(asynctest.TestCase):
                 "app": {
                     "db_conn": SimpleNamespace(
                         **{
-                            "add_share": asynctest.CoroutineMock(),
-                            "edit_share": asynctest.CoroutineMock(),
-                            "delete_share": asynctest.CoroutineMock(),
-                            "delete_container_shares": asynctest.CoroutineMock(),
-                            "get_access_list": asynctest.CoroutineMock(),
-                            "get_shared_list": asynctest.CoroutineMock(),
-                            "get_access_container_details": asynctest.CoroutineMock(),
-                            "get_shared_container_details": asynctest.CoroutineMock(),
+                            "add_share": unittest.mock.AsyncMock(),
+                            "edit_share": unittest.mock.AsyncMock(),
+                            "delete_share": unittest.mock.AsyncMock(),
+                            "delete_container_shares": unittest.mock.AsyncMock(),
+                            "get_access_list": unittest.mock.AsyncMock(),
+                            "get_shared_list": unittest.mock.AsyncMock(),
+                            "get_access_container_details": unittest.mock.AsyncMock(),
+                            "get_shared_container_details": unittest.mock.AsyncMock(),
                         }
                     ),
                 },

--- a/tests/sharing/test_bindings_bind.py
+++ b/tests/sharing/test_bindings_bind.py
@@ -1,24 +1,21 @@
 """Module for testing the bindings module / class."""
 
 
-import unittest.mock
+import unittest
 from types import SimpleNamespace
-
-
-import asynctest
 
 
 from swift_browser_ui.sharing.bindings.bind import SwiftXAccountSharing
 
 
-class MockRequestContextManager(asynctest.TestCase):
+class MockRequestContextManager(unittest.IsolatedAsyncioTestCase):
     """Mock class for aiohttp request context manager."""
 
     def __init__(self, *args, **kwargs):
         """."""
         self.resp = SimpleNamespace(
             **{
-                "text": asynctest.CoroutineMock(return_value="[]"),
+                "text": unittest.mock.AsyncMock(return_value="[]"),
                 "status": 200,
                 "url": "http://example",
             }
@@ -44,7 +41,7 @@ class MockGenericContextManager(MockRequestContextManager):
 # Delete method mock context manager won't have any assertions in the
 # __aexit__ method, since there's no real assertable functionality.
 # Functionality will be tested in integration testing.
-class MockDeleteContextManager(asynctest.TestCase):
+class MockDeleteContextManager(unittest.IsolatedAsyncioTestCase):
     """Mock class for aiohttp delete context manager."""
 
     def __init__(self, *args, **kwargs):
@@ -61,14 +58,14 @@ class MockDeleteContextManager(asynctest.TestCase):
         """."""
 
 
-class BindingsClassTestCase(asynctest.TestCase):
+class BindingsClassTestCase(unittest.IsolatedAsyncioTestCase):
     """Bindings class test case."""
 
     def setUp(self):
         """Set up relevant mocks."""
         self.session_mock = SimpleNamespace(
             **{
-                "close": asynctest.CoroutineMock(),
+                "close": unittest.mock.AsyncMock(),
                 "get": MockGenericContextManager,
                 "post": MockGenericContextManager,
                 "patch": MockGenericContextManager,

--- a/tests/sharing/test_db.py
+++ b/tests/sharing/test_db.py
@@ -2,30 +2,27 @@
 
 
 import unittest
-import unittest.mock
 from types import SimpleNamespace
 
-import asynctest
-import asynctest.mock
 import asyncpg
 
 from swift_browser_ui.sharing.db import DBConn
 import datetime
 
 
-class DBConnTestClass(asynctest.TestCase):
+class DBConnTestClass(unittest.IsolatedAsyncioTestCase):
     """Test database connection class code."""
 
     def setUp(self):
         """Set up necessary mocks."""
         self.asyncpg_pool_mock = SimpleNamespace(
             **{
-                "close": asynctest.mock.CoroutineMock(),
+                "close": unittest.mock.AsyncMock(),
                 "terminate": unittest.mock.Mock(),
             }
         )
 
-        self.asyncpg_pool_mock = asynctest.CoroutineMock(
+        self.asyncpg_pool_mock = unittest.mock.AsyncMock(
             return_value=self.asyncpg_pool_mock,
         )
         self.patch_asyncpg_pool = unittest.mock.patch(
@@ -33,7 +30,7 @@ class DBConnTestClass(asynctest.TestCase):
             new=self.asyncpg_pool_mock,
         )
 
-        self.asyncpg_connect_mock_connection_error = asynctest.CoroutineMock(
+        self.asyncpg_connect_mock_connection_error = unittest.mock.AsyncMock(
             side_effect=ConnectionError
         )
         self.patch_asyncpg_pool_connection_error = unittest.mock.patch(
@@ -41,7 +38,7 @@ class DBConnTestClass(asynctest.TestCase):
             new=self.asyncpg_connect_mock_connection_error,
         )
 
-        self.asyncpg_connect_mock_invalid_pwd = asynctest.CoroutineMock(
+        self.asyncpg_connect_mock_invalid_pwd = unittest.mock.AsyncMock(
             side_effect=asyncpg.InvalidPasswordError("Invalid")
         )
         self.patch_asyncpg_pool_invalid_password = unittest.mock.patch(
@@ -54,7 +51,7 @@ class DBConnTestClass(asynctest.TestCase):
             "swift_browser_ui.sharing.db.os.environ.get", new=self.os_environ_mock
         )
 
-        self.asyncio_sleep_mock = asynctest.CoroutineMock(side_effect=Exception)
+        self.asyncio_sleep_mock = unittest.mock.AsyncMock(side_effect=Exception)
         self.patch_asyncio_sleep = unittest.mock.patch(
             "swift_browser_ui.sharing.db.asyncio.sleep", new=self.asyncio_sleep_mock
         )
@@ -63,7 +60,7 @@ class DBConnTestClass(asynctest.TestCase):
 
     def test_db_erase(self):
         """Test connection erase method."""
-        mock_terminate = asynctest.mock.CoroutineMock()
+        mock_terminate = unittest.mock.Mock()
         self.db.pool = SimpleNamespace(**{"terminate": mock_terminate})
         self.db.erase()
         mock_terminate.assert_called_once()
@@ -103,18 +100,18 @@ class DBConnTestClass(asynctest.TestCase):
             self.db.pool.close.assert_awaited_once()
 
 
-class DBMethodTestCase(asynctest.TestCase):
+class DBMethodTestCase(unittest.IsolatedAsyncioTestCase):
     """Test database query methods."""
 
     def setUp(self):
         """Set up required mocks."""
-        self.connection_transaction_mock = asynctest.MagicMock(
+        self.connection_transaction_mock = unittest.mock.MagicMock(
             asyncpg.Connection.transaction
         )
         mock_date = datetime.datetime(2020, 7, 15, 12, 25, 26, 791901)
 
         class AsyncpgConnectionMock:
-            fetch = asynctest.CoroutineMock(
+            fetch = unittest.mock.AsyncMock(
                 return_value=[
                     {
                         "container": "test-container",
@@ -127,7 +124,7 @@ class DBMethodTestCase(asynctest.TestCase):
                     }
                 ]
             )
-            fetchrow = asynctest.CoroutineMock(
+            fetchrow = unittest.mock.AsyncMock(
                 return_value={
                     "r_read": True,
                     "r_write": True,
@@ -138,7 +135,7 @@ class DBMethodTestCase(asynctest.TestCase):
                     "address": "test-address",
                 }
             )
-            execute = asynctest.CoroutineMock()
+            execute = unittest.mock.AsyncMock()
             transaction = self.connection_transaction_mock
 
             def __init__(self):
@@ -155,7 +152,7 @@ class DBMethodTestCase(asynctest.TestCase):
 
         self.asyncpg_pool_mock = SimpleNamespace(
             **{
-                "fetch": asynctest.CoroutineMock(
+                "fetch": unittest.mock.AsyncMock(
                     return_value=[
                         {
                             "container": "test-container",
@@ -168,7 +165,7 @@ class DBMethodTestCase(asynctest.TestCase):
                         }
                     ]
                 ),
-                "fetchrow": asynctest.CoroutineMock(
+                "fetchrow": unittest.mock.AsyncMock(
                     return_value={
                         "r_read": True,
                         "r_write": True,

--- a/tests/sharing/test_server.py
+++ b/tests/sharing/test_server.py
@@ -2,17 +2,13 @@
 
 
 import unittest
-import unittest.mock
-
-
 import aiohttp.web
-import asynctest
 
 
 from swift_browser_ui.sharing.server import init_server, run_server_devel
 
 
-class TestInitServer(asynctest.TestCase):
+class TestInitServer(unittest.IsolatedAsyncioTestCase):
     """Test case for server initialization."""
 
     async def test_init_server(self):

--- a/tests/ui_unit/mock_server.py
+++ b/tests/ui_unit/mock_server.py
@@ -2,8 +2,8 @@
 
 
 from os import environ
-import unittest.mock
 import logging
+import unittest.mock
 
 
 import swift_browser_ui.ui.server

--- a/tests/ui_unit/test_api.py
+++ b/tests/ui_unit/test_api.py
@@ -8,7 +8,6 @@ import types
 import logging
 
 from aiohttp.web import HTTPNotFound
-import asynctest
 
 from swiftclient.service import SwiftError
 
@@ -34,7 +33,7 @@ from swift_browser_ui.ui.settings import setd
 from tests.ui_unit.creation import get_request_with_mock_openstack
 
 
-class APITestClass(asynctest.TestCase):
+class APITestClass(unittest.IsolatedAsyncioTestCase):
     """Testing the Object Browser API."""
 
     def setUp(self):
@@ -457,7 +456,7 @@ class APITestClass(asynctest.TestCase):
         self.request = None
 
 
-class TestProxyFunctions(asynctest.TestCase):
+class TestProxyFunctions(unittest.IsolatedAsyncioTestCase):
     """Test the handlers proxying information to the upload runner."""
 
     def setUp(self):
@@ -492,12 +491,12 @@ class TestProxyFunctions(asynctest.TestCase):
             "swift_browser_ui.ui.api.api_check", self.api_check_mock
         )
 
-        self.session_open_mock = asynctest.CoroutineMock(return_value="test_runner_id")
+        self.session_open_mock = unittest.mock.AsyncMock(return_value="test_runner_id")
         self.patch_runner_session = unittest.mock.patch(
             "swift_browser_ui.ui.api.open_upload_runner_session", self.session_open_mock
         )
 
-        self.sign_mock = asynctest.CoroutineMock(
+        self.sign_mock = unittest.mock.AsyncMock(
             return_value={
                 "signature": "test-signature",
                 "valid": "test-valid",

--- a/tests/ui_unit/test_discover.py
+++ b/tests/ui_unit/test_discover.py
@@ -1,14 +1,12 @@
 """Module for testing ``swift_browser_ui.discover``."""
 
 import json
-import unittest.mock
-
-import asynctest
+import unittest
 
 from swift_browser_ui.ui.discover import handle_discover
 
 
-class DiscoverTestClass(asynctest.TestCase):
+class DiscoverTestClass(unittest.IsolatedAsyncioTestCase):
     """Testing the endpoint discovery handler."""
 
     async def test_valid_json_reply(self):

--- a/tests/ui_unit/test_front.py
+++ b/tests/ui_unit/test_front.py
@@ -4,7 +4,7 @@
 import unittest
 import os
 
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp.test_utils import AioHTTPTestCase
 
 from swift_browser_ui.ui.server import servinit
 
@@ -21,7 +21,6 @@ class FrontendTestCase(AioHTTPTestCase):
         """."""
         return True
 
-    @unittest_run_loop
     async def test_browse(self):
         """Test /browse handler."""
         patch_setd = unittest.mock.patch(
@@ -36,7 +35,6 @@ class FrontendTestCase(AioHTTPTestCase):
             self.assertEqual(response.status, 200)
             self.assertEqual(response.headers["Content-type"], "text/html")
 
-    @unittest_run_loop
     async def test_index(self):
         """Test / handler."""
         patch_setd = unittest.mock.patch(
@@ -51,7 +49,6 @@ class FrontendTestCase(AioHTTPTestCase):
             self.assertEqual(response.status, 200)
             self.assertEqual(response.headers["Content-type"], "text/html")
 
-    @unittest_run_loop
     async def test_loginpassword(self):
         """Test /loginpassword handler."""
         patch_setd = unittest.mock.patch(

--- a/tests/ui_unit/test_login.py
+++ b/tests/ui_unit/test_login.py
@@ -6,7 +6,6 @@ import unittest
 import json
 import types
 
-import asynctest
 import aiohttp
 
 import swift_browser_ui.ui.login
@@ -28,7 +27,7 @@ from tests.common.mockups import (
 _path = "/auth/OS-FEDERATION/identity_providers/haka/protocols/saml2/websso"
 
 
-class LoginTestClass(asynctest.TestCase):
+class LoginTestClass(unittest.IsolatedAsyncioTestCase):
     """Testing the Object Browser API."""
 
     async def test_handle_login(self):

--- a/tests/ui_unit/test_middlewares.py
+++ b/tests/ui_unit/test_middlewares.py
@@ -6,7 +6,6 @@ import os
 
 from aiohttp.web import HTTPUnauthorized, HTTPForbidden, HTTPNotFound
 from aiohttp.web import Response, HTTPClientError, FileResponse
-import asynctest
 
 from swift_browser_ui.ui.middlewares import error_middleware
 from swift_browser_ui.ui.front import index
@@ -40,7 +39,7 @@ async def return_400_handler(with_exception):
     return Response(status=400)
 
 
-class MiddlewareTestClass(asynctest.TestCase):
+class MiddlewareTestClass(unittest.IsolatedAsyncioTestCase):
     """Testing the error middleware."""
 
     async def test_401_return(self):

--- a/tests/ui_unit/test_server.py
+++ b/tests/ui_unit/test_server.py
@@ -9,9 +9,8 @@ import os
 import unittest
 import ssl
 
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp.test_utils import AioHTTPTestCase
 import aiohttp
-import asynctest
 
 from swift_browser_ui.ui.server import servinit, run_server_insecure
 from swift_browser_ui.ui.server import kill_sess_on_shutdown, run_server_secure
@@ -24,7 +23,7 @@ from tests.ui_unit.creation import get_request_with_mock_openstack
 setd["static_directory"] = os.getcwd() + "/swift_browser_ui_frontend"
 
 
-class TestServinitMethod(asynctest.TestCase):
+class TestServinitMethod(unittest.IsolatedAsyncioTestCase):
     """Small test case for servinit."""
 
     async def test_servinit(self):
@@ -35,7 +34,7 @@ class TestServinitMethod(asynctest.TestCase):
         self.assertTrue(app is not None)
 
 
-class TestServerShutdownHandler(asynctest.TestCase):
+class TestServerShutdownHandler(unittest.IsolatedAsyncioTestCase):
     """Test case for the server graceful shutdown handler."""
 
     async def test_kill_sess_on_shutdown(self):
@@ -92,7 +91,6 @@ class AppTestCase(AioHTTPTestCase):
         """Retrieve web Application for test."""
         return await servinit()
 
-    @unittest_run_loop
     async def test_working_routes(self):
         """
         Test all the specified server routes.

--- a/tests/ui_unit/test_shell.py
+++ b/tests/ui_unit/test_shell.py
@@ -1,6 +1,6 @@
 """Module for testing the project command line interface."""
 
-import unittest.mock
+import unittest
 from click.testing import CliRunner
 
 from swift_browser_ui.ui.shell import cli, start

--- a/tests/ui_unit/test_signature.py
+++ b/tests/ui_unit/test_signature.py
@@ -4,7 +4,6 @@
 import types
 import unittest
 
-import asynctest
 import aiohttp
 
 from swift_browser_ui.ui.signature import handle_signature_request
@@ -14,7 +13,7 @@ from swift_browser_ui.ui.signature import handle_ext_token_list
 from swift_browser_ui.ui.signature import handle_form_post_signature
 
 
-class SignatureMiscTestClass(asynctest.TestCase):
+class SignatureMiscTestClass(unittest.IsolatedAsyncioTestCase):
     """Class for testing the signature module misc handlers."""
 
     def setUp(self):
@@ -24,7 +23,7 @@ class SignatureMiscTestClass(asynctest.TestCase):
             "swift_browser_ui.ui._convenience.session_check", self.session_check_mock
         )
 
-        self.sign_mock = asynctest.CoroutineMock(
+        self.sign_mock = unittest.mock.AsyncMock(
             return_value={
                 "valid": 15000000,
                 "signature": "test-signature",
@@ -67,7 +66,7 @@ class SignatureMiscTestClass(asynctest.TestCase):
             }
         )
 
-        self.get_tempurl_key_mock = asynctest.CoroutineMock(return_value="test-key")
+        self.get_tempurl_key_mock = unittest.mock.AsyncMock(return_value="test-key")
         self.get_tempurl_key_patch = unittest.mock.patch(
             "swift_browser_ui.ui._convenience.get_tempurl_key", self.get_tempurl_key_mock
         )
@@ -99,7 +98,7 @@ class SignatureMiscTestClass(asynctest.TestCase):
             self.assertIsInstance(resp, aiohttp.web.Response)
 
 
-class SignatureTokenTestClass(asynctest.TestCase):
+class SignatureTokenTestClass(unittest.IsolatedAsyncioTestCase):
     """Class for testing the token creation proxy handlers."""
 
     def setUp(self):
@@ -117,14 +116,14 @@ class SignatureTokenTestClass(asynctest.TestCase):
                     },
                     "api_client": types.SimpleNamespace(
                         **{
-                            "post": asynctest.CoroutineMock(
+                            "post": unittest.mock.AsyncMock(
                                 return_value=types.SimpleNamespace(**{"status": 200})
                             ),
-                            "delete": asynctest.CoroutineMock(),
-                            "get": asynctest.CoroutineMock(
+                            "delete": unittest.mock.AsyncMock(),
+                            "get": unittest.mock.AsyncMock(
                                 return_value=types.SimpleNamespace(
                                     **{
-                                        "text": asynctest.CoroutineMock(
+                                        "text": unittest.mock.AsyncMock(
                                             return_value="test-token"
                                         )
                                     }
@@ -147,11 +146,11 @@ class SignatureTokenTestClass(asynctest.TestCase):
                     },
                     "api_client": types.SimpleNamespace(
                         **{
-                            "post": asynctest.CoroutineMock(
+                            "post": unittest.mock.AsyncMock(
                                 return_value=types.SimpleNamespace(
                                     **{
                                         "status": 500,
-                                        "text": asynctest.CoroutineMock(
+                                        "text": unittest.mock.AsyncMock(
                                             return_value="Error"
                                         ),
                                         "url": "http://example-endpoint",
@@ -180,7 +179,7 @@ class SignatureTokenTestClass(asynctest.TestCase):
             "swift_browser_ui.ui.signature.setd", self.setd_mock_missing_endpoints
         )
 
-        self.sign_mock = asynctest.CoroutineMock(
+        self.sign_mock = unittest.mock.AsyncMock(
             return_value={
                 "valid": 15000000,
                 "signature": "test-signature",

--- a/tests/upload/test_api.py
+++ b/tests/upload/test_api.py
@@ -2,17 +2,16 @@
 
 
 import types
-import unittest.mock
+import unittest
 
 import aiohttp.web
-import asynctest.mock
 
 import swift_browser_ui.upload.api
 
 import tests.common.mockups
 
 
-class APITestClass(asynctest.TestCase):
+class APITestClass(unittest.IsolatedAsyncioTestCase):
     """Test class for swift_browser_ui.upload.api functions."""
 
     def setUp(self) -> None:
@@ -26,13 +25,11 @@ class APITestClass(asynctest.TestCase):
 
         self.mock_upload_instance = types.SimpleNamespace(
             **{
-                "a_add_chunk": asynctest.mock.CoroutineMock(return_value="add-success"),
-                "a_check_segment": asynctest.mock.CoroutineMock(
-                    return_value="check-success"
-                ),
+                "a_add_chunk": unittest.mock.AsyncMock(return_value="add-success"),
+                "a_check_segment": unittest.mock.AsyncMock(return_value="check-success"),
             }
         )
-        self.mock_get_upload_instance = asynctest.mock.CoroutineMock(
+        self.mock_get_upload_instance = unittest.mock.AsyncMock(
             return_value=self.mock_upload_instance
         )
         self.patch_get_upload_instance = unittest.mock.patch(
@@ -42,7 +39,7 @@ class APITestClass(asynctest.TestCase):
 
         self.mock_response = types.SimpleNamespace(
             **{
-                "prepare": asynctest.mock.CoroutineMock(),
+                "prepare": unittest.mock.AsyncMock(),
                 "headers": {},
             }
         )
@@ -53,13 +50,11 @@ class APITestClass(asynctest.TestCase):
             "aiohttp.web.StreamResponse", self.mock_streamresponse_init
         )
 
-        self.mock_a_begin = asynctest.mock.CoroutineMock()
-        self.mock_a_get_type = asynctest.mock.CoroutineMock(
-            return_value="binary/octet-stream"
-        )
-        self.mock_a_get_size = asynctest.mock.CoroutineMock(return_value="1024")
-        self.mock_a_write = asynctest.mock.CoroutineMock()
-        self.mock_a_begin_container = asynctest.mock.CoroutineMock()
+        self.mock_a_begin = unittest.mock.AsyncMock()
+        self.mock_a_get_type = unittest.mock.AsyncMock(return_value="binary/octet-stream")
+        self.mock_a_get_size = unittest.mock.AsyncMock(return_value="1024")
+        self.mock_a_write = unittest.mock.AsyncMock()
+        self.mock_a_begin_container = unittest.mock.AsyncMock()
         self.mock_download = types.SimpleNamespace(
             **{
                 "a_begin_download": self.mock_a_begin,
@@ -102,7 +97,7 @@ class APITestClass(asynctest.TestCase):
 
     async def test_handle_replicate_container(self):
         """Test swift_browser_ui.upload.api.handle_replicate_container."""
-        mock_copy_from_container = asynctest.mock.CoroutineMock()
+        mock_copy_from_container = unittest.mock.AsyncMock()
         mock_replicator = types.SimpleNamespace(
             **{"a_copy_from_container": mock_copy_from_container}
         )
@@ -135,7 +130,7 @@ class APITestClass(asynctest.TestCase):
 
     async def test_handle_replicate_object(self):
         """Test swift_brwser_ui.upload.api.handle_replicate_object."""
-        mock_copy_object = asynctest.mock.CoroutineMock()
+        mock_copy_object = unittest.mock.AsyncMock()
         mock_replicator = types.SimpleNamespace(**{"a_copy_object": mock_copy_object})
         mock_init_replicator = unittest.mock.Mock(return_value=mock_replicator)
         patch_replicator = unittest.mock.patch(
@@ -171,13 +166,13 @@ class APITestClass(asynctest.TestCase):
     async def test_handle_post_object_chunk(self):
         """Test swift_browser_ui.upload.api.handle_post_object_chunk."""
         # Test for the edge cases of rerouted POST
-        mock_handle_repl_object = asynctest.mock.CoroutineMock(
+        mock_handle_repl_object = unittest.mock.AsyncMock(
             return_value=aiohttp.web.Response()
         )
         patch_handle_repl_object = unittest.mock.patch(
             "swift_browser_ui.upload.api.handle_replicate_object", mock_handle_repl_object
         )
-        mock_handle_repl_container = asynctest.mock.CoroutineMock(
+        mock_handle_repl_container = unittest.mock.AsyncMock(
             return_value=aiohttp.web.Response()
         )
         patch_handle_repl_container = unittest.mock.patch(
@@ -197,7 +192,7 @@ class APITestClass(asynctest.TestCase):
         mock_handle_repl_container.assert_called_once()
 
         # The actual test for uploaded object chunk post
-        mock_parse_multipart_in = asynctest.mock.CoroutineMock(
+        mock_parse_multipart_in = unittest.mock.AsyncMock(
             return_value=("example-query", "example-data")
         )
         patch_parse_multipart_in = unittest.mock.patch(
@@ -245,9 +240,7 @@ class APITestClass(asynctest.TestCase):
         # Handle edge case of uploaded object chunk check
         req = tests.common.mockups.Mock_Request()
         req.set_query({"resumableChunkNumber": 1})
-        mock_get_object_chunk = asynctest.mock.CoroutineMock(
-            return_value="get-chunk-success"
-        )
+        mock_get_object_chunk = unittest.mock.AsyncMock(return_value="get-chunk-success")
         patch_get_object_chunk = unittest.mock.patch(
             "swift_browser_ui.upload.api.handle_get_object_chunk", mock_get_object_chunk
         )

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -1,16 +1,15 @@
 """Unit tests for swift_browser_ui.upload.auth module."""
 
 
-import unittest.mock
+import unittest
 
-import asynctest
 import aiohttp.web
 
 import swift_browser_ui.upload.auth
 import tests.common.mockups
 
 
-class AuthTestClass(asynctest.TestCase):
+class AuthTestClass(unittest.IsolatedAsyncioTestCase):
     """Test class for swift_browser_ui.upload.auth functions."""
 
     def setUp(self):
@@ -48,11 +47,11 @@ class AuthTestClass(asynctest.TestCase):
 
     async def test_handle_validate_authentication(self):
         """Test swift_browser_ui.upload.auth.handle_validate_authentication."""
-        handler_mock = asynctest.CoroutineMock()
+        handler_mock = unittest.mock.AsyncMock()
         req = tests.common.mockups.Mock_Request()
         req.set_path("/")
 
-        t_singature_mock = asynctest.CoroutineMock()
+        t_singature_mock = unittest.mock.AsyncMock()
         t_signature_patch = unittest.mock.patch(
             "swift_browser_ui.common.signature.test_signature", t_singature_mock
         )
@@ -82,7 +81,7 @@ class AuthTestClass(asynctest.TestCase):
         req = tests.common.mockups.Mock_Request()
         req.set_path("/health")
 
-        handler_mock = asynctest.CoroutineMock()
+        handler_mock = unittest.mock.AsyncMock()
 
         await swift_browser_ui.upload.auth.handle_validate_authentication(
             req,

--- a/tests/upload/test_common.py
+++ b/tests/upload/test_common.py
@@ -1,9 +1,8 @@
 """Unit tests for swift_browser_ui.upload.common module."""
 
 
-import unittest.mock
+import unittest
 
-import asynctest
 import aiohttp
 
 import swift_browser_ui.upload.common
@@ -11,7 +10,7 @@ import swift_browser_ui.upload.common
 import tests.common.mockups
 
 
-class CommonTestClass(asynctest.TestCase):
+class CommonTestClass(unittest.IsolatedAsyncioTestCase):
     """Test class for testing swift_browser_ui.upload.common functions."""
 
     def setUp(self):
@@ -72,7 +71,7 @@ class CommonTestClass(asynctest.TestCase):
 
     async def test_get_upload_instance(self):
         """Test get_upload_instance function."""
-        mock_upload = asynctest.create_autospec(
+        mock_upload = unittest.mock.create_autospec(
             swift_browser_ui.upload.common.upload.ResumableFileUploadProxy
         )
         patch_upload = unittest.mock.patch(

--- a/tests/upload/test_server.py
+++ b/tests/upload/test_server.py
@@ -1,13 +1,13 @@
 """Test swift_browser_ui.upload.server module."""
 
 
+import unittest
 import aiohttp.web
-import asynctest
 
 import swift_browser_ui.upload.server
 
 
-class ServerTestClass(asynctest.TestCase):
+class ServerTestClass(unittest.IsolatedAsyncioTestCase):
     """Test swift_browser_ui.upload.server module functions."""
 
     async def test_servinit(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
adjust for:
- `DeprecationWarning: Decorator "@unittest_run_loop" is no longer needed in aiohttp 3.8+`
- `DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead` from `asynctest` library

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Part of #22 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] refactor unit tests

### Changes Made

<!-- List changes made. -->
1. remove `asynctest` in favour of using unittest library Async functionality
2. other small adjustments

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
