### PR TITLE
Fix operations with large objects in shared containers.

### DIFF
--- a/swift_browser_ui/upload/common.py
+++ b/swift_browser_ui/upload/common.py
@@ -9,6 +9,10 @@ import keystoneauth1.session
 from swift_browser_ui.upload import upload
 
 
+DATA_PREFIX = "data/"
+SEGMENTS_PREFIX = ".segments/"
+
+
 def generate_download_url(
     host: str,
     container: typing.Union[str, None] = None,

--- a/swift_browser_ui/upload/download.py
+++ b/swift_browser_ui/upload/download.py
@@ -20,6 +20,7 @@ from swift_browser_ui.upload.common import (
     generate_download_url,
     get_path_from_list,
     get_download_host,
+    SEGMENTS_PREFIX,
 )
 
 
@@ -307,6 +308,9 @@ class ContainerArchiveDownloadProxy:
             if len(path) > 1:
                 if path[0] in ret_fs.keys():
                     LOGGER.debug(f"Skipping path {path} as added.")
+                    continue
+                if path[0].endswith(SEGMENTS_PREFIX):
+                    LOGGER.debug(f"Skipping {SEGMENTS_PREFIX} for {path}.")
                     continue
 
                 LOGGER.debug(f"Adding directory for {path[0]} {path_prefix}")

--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -198,7 +198,27 @@ export function truncate(value, length) {
 }
 
 const SEGMENT_REGEX = /^\.segments\/(.*)\/[0-9]{8}$/;
+const DATA_PREFIX = "data/";
+
 export function filterSegments(objects) {
+  // Calculate the size of segmented objects before filtering
+  // Only works if segments come before the object in the array
+  let segmentedObjSizes = {};
+  objects.forEach((obj) => {
+    const name = obj.name.replace(DATA_PREFIX, "");
+    const nameFromSegment = SEGMENT_REGEX.exec(name);
+    if (nameFromSegment === null && name in segmentedObjSizes) {
+      obj.bytes = segmentedObjSizes[name];
+      return;
+    }
+    if (nameFromSegment === null) {
+      return;
+    }
+    if (!(nameFromSegment[1] in segmentedObjSizes)) {
+      segmentedObjSizes[nameFromSegment[1]] = 0;
+    }
+    segmentedObjSizes[nameFromSegment[1]] += obj.bytes;
+  });
   return objects.filter(o =>
     o.name.match(SEGMENT_REGEX) === null);
 }

--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -196,3 +196,9 @@ export function truncate(value, length) {
   }
   return value.length > length ? value.substr(0, length) + "..." : value;
 }
+
+const SEGMENT_REGEX = /^\.segments\/(.*)\/[0-9]{8}$/;
+export function filterSegments(objects) {
+  return objects.filter(o =>
+    o.name.match(SEGMENT_REGEX) === null);
+}

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -11,6 +11,7 @@ import {
   getTagsForContainer,
   getTagsForObjects,
   makeGetObjectsMetaURL,
+  filterSegments,
 } from "./conv";
 
 Vue.use(Vuex);
@@ -171,7 +172,7 @@ const store = new Vuex.Store({
         ).then(
           (ret) => {
             commit("loading", false);
-            commit("updateObjects", ret);
+            commit("updateObjects", filterSegments(ret));
           },
         ).catch(() => {
           commit("updateObjects", []);
@@ -185,7 +186,7 @@ const store = new Vuex.Store({
           if (ret.status != 200) {
             commit("loading", false);
           }
-          commit("updateObjects", ret);
+          commit("updateObjects", filterSegments(ret));
           commit("loading", false);
         }).catch(() => {
           commit("updateObjects", []);


### PR DESCRIPTION
### Description

To fix the issues with operations on shared containers, we
upload large objects to the same container. Instead of using a
container for segments, they go to a pseudo-folder.

### Related issues
Fixes #388

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

- Upload segments to the same container under `.segments/`
- Upload regular objects to `data/`
- Hide segments in the UI
- Calculate size of large objects
- Container downloads ignore the segments folder

### Testing

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
