### PR TITLE
Fix buefy broken link to docs.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ Out of the box the ``swift-browser-ui`` offers:
 * support for additional features like uploading files >5GiB in size;
 * support for federated authentication of an user with their HAKA credentials
   using OpenStack Keystone;
-* UI based on `Vue.js <https://vuejs.org/>`_ with `Buefy framework <https://buefy.org/documentation>`_;
+* UI based on `Vue.js <https://vuejs.org/>`_ with `Buefy framework <https://buefy.org>`_;
 * asynchronous web server.
 
 


### PR DESCRIPTION
### Description

Buefy updated their website, and broke their routes. https://buefy.org/documentation doesn't go the page.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
