### PR TITLE
fix: container download link after page refresh

### DIFF
--- a/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
@@ -48,6 +48,9 @@ export default {
     container: function () {
       this.createDownloadLink();
     },
+    active: function () {
+      this.createDownloadLink();
+    },
   },
   beforeMount () {
     this.createDownloadLink();


### PR DESCRIPTION
### Description
Refreshing the page inside a container made the container download link to have `undefined` for project in the URL.

### Related issues
Fixes #469.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
