### PR TITLE
Disable sharing containers in write-only mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - handle test chunk uploaded request as `204` instead of `404` as recommended by https://github.com/23/resumable.js#handling-get-or-test-requests
     - remove forgotten console.logs
 
+### Removed
+- The possibility to share containers with write-only (file drop) permissions (GH #475)
 
 [Unreleased]: https://github.com/CSCfi/swift-browser-ui/compare/1.1.0b8...devel

--- a/swift_browser_ui_frontend/src/views/DirectShare.vue
+++ b/swift_browser_ui_frontend/src/views/DirectShare.vue
@@ -97,6 +97,18 @@ export default {
       return this.$store.state.active;
     },
   },
+  watch: {
+    read: function () {
+      if(!this.read) {
+        this.write = false;
+      }
+    },
+    write: function () {
+      if(this.write) {
+        this.read = true;
+      }
+    },
+  },
   beforeMount () {
     this.setActive(100);
     this.setParams(100);

--- a/swift_browser_ui_frontend/src/views/Sharing.vue
+++ b/swift_browser_ui_frontend/src/views/Sharing.vue
@@ -83,6 +83,18 @@ export default {
       loading: false,
     };
   },
+  watch: {
+    read: function () {
+      if(!this.read) {
+        this.write = false;
+      }
+    },
+    write: function () {
+      if(this.write) {
+        this.read = true;
+      }
+    },
+  },
   beforeMount () {
     this.checkContainer();
   },


### PR DESCRIPTION
### Description
Our swift backend behaves differently than expected, and we're disabling write-only container shares to prevent unexpected behaviour.

### Related issues
Fixes #475.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

In `ShareView` and `DirectShare` views (Container sharing pages):
- enabling `write` enables `read`
- disabling `read` disables `write`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
