### PR TITLE
Bugfix/fix availability check comparison

### DIFF
--- a/swift_browser_ui/ui/_convenience.py
+++ b/swift_browser_ui/ui/_convenience.py
@@ -119,7 +119,7 @@ async def get_availability_from_token(token: str, client: aiohttp.ClientSession)
     # get a 401 response when we do initiate_os_service
     filtered_projects = list(
         filter(
-            lambda d: d.get("enabled") is not False,
+            lambda d: d["enabled"] if "enabled" in d else False,
             output_projects["projects"],  # type: ignore
         )
     )

--- a/swift_browser_ui/ui/front.py
+++ b/swift_browser_ui/ui/front.py
@@ -18,9 +18,11 @@ async def browse(request: aiohttp.web.Request) -> aiohttp.web.FileResponse:
         session["projects"]
         session["token"]
         if session["at"] + 28800 < time.time():
+            request.app["Log"].info("A session was invalidated due to an expired token.")
             session.invalidate()
             raise aiohttp.web.HTTPUnauthorized(reason="Token expired")
-    except KeyError:
+    except KeyError as e:
+        request.app["Log"].info(f"A session was invalidated due to invalid token. {e}")
         raise aiohttp.web.HTTPUnauthorized(reason="No valid session.")
     response = aiohttp.web.FileResponse(
         str(setd["static_directory"]) + "/browse.html",

--- a/swift_browser_ui/ui/login.py
+++ b/swift_browser_ui/ui/login.py
@@ -176,7 +176,7 @@ async def login_with_token(
     response: typing.Union[aiohttp.web.Response, aiohttp.web.FileResponse]
     response = aiohttp.web.Response(
         status=303,
-        body="",
+        body=None,
     )
     client = request.app["api_client"]
     session = await aiohttp_session.new_session(request)
@@ -212,6 +212,16 @@ async def login_with_token(
             if resp.status == 403:
                 raise aiohttp.web.HTTPForbidden(reason="No access to service with token.")
             ret = await resp.json()
+
+            request.app["Log"].debug(f"token output: {ret}")
+
+            obj_role = False
+            request.app["Log"].debug(f'roles: {ret["token"]["roles"]}')
+            for role in ret["token"]["roles"]:
+                if role["name"] == "object_store_user":
+                    obj_role = True
+            if not obj_role:
+                continue
 
             scoped = resp.headers["X-Subject-Token"]
             # Use the first available public endpoint

--- a/tests/ui_unit/test_login.py
+++ b/tests/ui_unit/test_login.py
@@ -218,6 +218,11 @@ class LoginTestClass(tests.common.mockups.APITestBase):
                 "user": {
                     "name": "test-user",
                 },
+                "roles": [
+                    {
+                        "name": "object_store_user",
+                    },
+                ],
                 "catalog": [
                     {
                         "type": "object-store",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Checking for project's `enabled` state is not enough to filter out projects without access to object storage. New implementation adds project filtering based on the user having `object_store_user` role, which determines access to the object storage.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Add filtering based on Openstack Keystone roles
* Add Openstack Keystone roles to mock token output for testing
* Two log events on invalid sessions that were kept as possibly useful

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
@blankdots for noticing the miss in filtering out unsuitable projects