### PR TITLE
use redis cookie storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** move to aiohttp_session with Redis as session store replacing own implementation
+- **BREAKING** use own client for Openstack Swift and Keystone APIs to remove synchronous parts of codebase
 - **BREAKING** Rename code occurrences of *bucket* to *container* (GH #471)
 - Updated dependencies in front-end as well as node.js base image to `node:14.18.3-alpine3.15`
 - Redirect to front page when the session has expired. (GH #461)
@@ -69,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **BREAKING** session handling without redis as session backend
 - The possibility to share containers with write-only (file drop) permissions (GH #475)
 - GH (GH #493) redesign upload UI 
     - removed vue-material-design-icons 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ uvloop==0.16.0
 gunicorn>=20.0.1
 certifi==2021.10.8
 asyncpg==0.25.0
+aioredis==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
         "uvloop==0.16.0",
         "certifi==2021.10.8",
         "asyncpg==0.25.0",
+        "aioredis==2.0.1",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
We need too much session data to be stored into a session cookie, thus moving to using `aiohttp_session` with Redis support.

This change breaks compatibility when running in environments without redis configured. Session storage in Redis allows scaling the UI API properly.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Move from `EncryptedCookieStorage` to `RedisStorage`
* Configure necessary setup for opening a Redis connection

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->