### PR TITLE
Fix editing object tags

### DIFF
--- a/swift_browser_ui_frontend/src/views/EditObject.vue
+++ b/swift_browser_ui_frontend/src/views/EditObject.vue
@@ -110,7 +110,7 @@ export default {
       ];
       updateObjectMeta(
         this.$route.params.project,
-        this.container,
+        this.container.name,
         objectMeta,
       ).then(async () => {
         if(this.$route.name === "EditObjectView") {


### PR DESCRIPTION
### Description
Editing object tags was passing an object instead of a string for container name.

### Related issues
Fixes #517

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
