### PR TITLE
Search results - tags first

### DIFF
--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -533,9 +533,9 @@ export default {
           .limit(1000)
           .toArray();
 
-      this.searchResults = this.searchResults.concat(
-        objects.sort(rankedSort).slice(0, 100),
-      );
+      this.searchResults = this.searchResults
+        .concat(objects.sort(rankedSort).slice(0, 100))
+        .sort(rankedSort);
       this.isSearching = false;
     },
     getSearchRoute: function(item) {


### PR DESCRIPTION
### Description
Search results should show results matching tags first. This change allows objects to show before containers.

This feature was missing from #506.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Sort results again after adding objects.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
