### PR TITLE
Fix getting object metadata for large containers.

### DIFF
--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -311,7 +311,7 @@ const store = new Vuex.Store({
 
       for (let i = 0; i < objects.length; i++) {
         // Object names end up in the URL, which has hard length limits.
-        // The aiohttp backend has a limit of 8192. The maximum size
+        // The aiohttp complains at 8190. The maximum size
         // for object name is 1024. Set it to a safe enough amount.
         // We split the requests to prevent reaching said limits.
         objectList.push(objects[i].name);
@@ -322,7 +322,11 @@ const store = new Vuex.Store({
         );
         if (
           i === objects.length - 1
-          || url.href.length > 8192
+          || makeGetObjectsMetaURL(
+            projectID,
+            container.name,
+            [...objectList, objects[i+1].name],
+          ).href.length >= 8190
         ) {
           let tags = await getTagsForObjects(
             projectID,


### PR DESCRIPTION
### Description
Prevents url from being longer than aiohttp's limit.

### Related issues
Fixes #504.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Checks if url will exceed maximum size, and make a request before that happens.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
