### PR TITLE
invalidate expired sessions

### DIFF
--- a/swift_browser_ui/ui/_convenience.py
+++ b/swift_browser_ui/ui/_convenience.py
@@ -8,10 +8,10 @@ API, cache manipulation, cookies etc.
 
 import secrets
 import logging
-import aiohttp_session
-import requests
 import typing
 
+import requests
+import aiohttp_session
 import aiohttp
 import aiohttp.web
 

--- a/swift_browser_ui/ui/front.py
+++ b/swift_browser_ui/ui/front.py
@@ -1,7 +1,6 @@
 """Web frontend functions for stand-alone running."""
 
 import typing
-import time
 
 import aiohttp.web
 import aiohttp_session
@@ -17,10 +16,6 @@ async def browse(request: aiohttp.web.Request) -> aiohttp.web.FileResponse:
     try:
         session["projects"]
         session["token"]
-        if session["at"] + 28800 < time.time():
-            request.app["Log"].info("A session was invalidated due to an expired token.")
-            session.invalidate()
-            raise aiohttp.web.HTTPUnauthorized(reason="Token expired")
     except KeyError as e:
         request.app["Log"].info(f"A session was invalidated due to invalid token. {e}")
         raise aiohttp.web.HTTPUnauthorized(reason="No valid session.")
@@ -44,9 +39,6 @@ async def index(
             session = await aiohttp_session.get_session(request)
             session["projects"]
             session["token"]
-            if session["at"] + 28800 < time.time():
-                session.invalidate()
-                raise aiohttp.web.HTTPUnauthorized(reason="Token expired")
             request.app["Log"].info("Redirecting an existing session to app")
             return aiohttp.web.Response(
                 status=303,
@@ -69,9 +61,6 @@ async def loginpassword(
             session = await aiohttp_session.get_session(request)
             session["projects"]
             session["token"]
-            if session["at"] + 28800 < time.time():
-                session.invalidate()
-                raise aiohttp.web.HTTPUnauthorized(reason="Token expired.")
             request.app["Log"].info("Redirecting an existing session to app")
             return aiohttp.web.Response(
                 status=303,

--- a/swift_browser_ui/ui/front.py
+++ b/swift_browser_ui/ui/front.py
@@ -10,16 +10,9 @@ from cryptography.fernet import InvalidToken
 from swift_browser_ui.ui.settings import setd
 
 
-async def browse(request: aiohttp.web.Request) -> aiohttp.web.FileResponse:
+async def browse(_: aiohttp.web.Request) -> aiohttp.web.FileResponse:
     """Serve the browser SPA when running without a proxy."""
-    session = await aiohttp_session.get_session(request)
-    try:
-        session["projects"]
-        session["token"]
-    except KeyError as e:
-        request.app["Log"].info(f"A session was invalidated due to invalid token. {e}")
-        raise aiohttp.web.HTTPUnauthorized(reason="No valid session.")
-    response = aiohttp.web.FileResponse(
+    return aiohttp.web.FileResponse(
         str(setd["static_directory"]) + "/browse.html",
         headers={
             "Cache-Control": "no-cache, no-store, must-revalidate",
@@ -27,7 +20,6 @@ async def browse(request: aiohttp.web.Request) -> aiohttp.web.FileResponse:
             "Expires": "0",
         },
     )
-    return response
 
 
 async def index(

--- a/swift_browser_ui/ui/middlewares.py
+++ b/swift_browser_ui/ui/middlewares.py
@@ -16,9 +16,9 @@ AiohttpHandler = typing.Callable[
 
 def return_error_response(error_code: int) -> web.Response:
     """Return the correct error page with correct status code."""
-    with open(str(setd["static_directory"]) + "/" + str(error_code) + ".html") as resp:
-        return web.Response(
-            body="".join(resp.readlines()),
+    with open(str(setd["static_directory"]) + "/" + str(error_code) + ".html") as f:
+        resp = web.Response(
+            body="".join(f.readlines()),
             status=error_code,
             content_type="text/html",
             headers={
@@ -27,6 +27,9 @@ def return_error_response(error_code: int) -> web.Response:
                 "Expires": "0",
             },
         )
+    if error_code == 401:
+        resp.headers["WWW-Authenticate"] = 'Bearer realm="/", charset="UTF-8"'
+    return resp
 
 
 @web.middleware

--- a/swift_browser_ui/ui/middlewares.py
+++ b/swift_browser_ui/ui/middlewares.py
@@ -36,11 +36,10 @@ async def check_session_at(
 ) -> web.Response:
     """Raise on expired sessions."""
     session = await aiohttp_session.get_session(request)
-    if "at" in session:
-        if session["at"] + 28800 < time.time():
-            session.invalidate()
-            if not ("login" in request.path or request.path == "/"):
-                raise web.HTTPUnauthorized(reason="Token expired.")
+    if "at" in session and session["at"] + 28800 < time.time():
+        session.invalidate()
+        if not ("login" in request.path or request.path == "/"):
+            raise web.HTTPUnauthorized(reason="Token expired.")
     return await handler(request)
 
 

--- a/tests/common/mockups.py
+++ b/tests/common/mockups.py
@@ -184,6 +184,7 @@ class APITestBase(unittest.IsolatedAsyncioTestCase):
                         "host": "https://localhost",
                     }
                 ),
+                "path": "/",
             }
         )
         super().setUp()


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Sessions that have an expired token should be properly checked for, not only for frontend requests. This is now handled in a middleware which is more aggressive about invalidating sessions that have expired.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Check for token expiration in middleware
* Remove token expiration checks elsewhere

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
