### PR TITLE
Feature/add lockdown support

### DIFF
--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -1,5 +1,7 @@
+
 ajaksi
 alapuolisesta
+alla
 aloitettiin
 annetut
 apin
@@ -24,6 +26,7 @@ erillinen
 erissä
 esimerkiksi
 esitetty
+estetty
 etsi
 etsittyä
 että
@@ -32,6 +35,7 @@ etusivun
 hakea
 haku
 hakuindeksi
+haluat
 haluatko
 halutako
 haluttu
@@ -65,9 +69,11 @@ johtaa
 johtua
 jonka
 jos
+jota
 julkinen
 julkiset
 julkisia
+kaikki
 kansio
 kansioille
 kansioina
@@ -86,6 +92,7 @@ käyttäjän
 käyttäjänimestä
 käyttöä
 käyttöliittymä
+käyttöliittymän
 käyttörajoista
 kehittänyt
 kelpaa
@@ -96,6 +103,8 @@ keskus
 kestää
 kiellettyä
 kirjaudu
+kirjautuaksesi
+kirjautumalla
 kirjautumisen
 kirjoitus
 kirjoitusoikeus
@@ -162,6 +171,7 @@ mikä
 mikäli
 minuutin
 mitätöi
+muiden
 muita
 mukaan
 muokataan
@@ -172,7 +182,9 @@ muussa
 muutaman
 muuttaa
 muuttaaksesi
+näkyvissä
 nämä
+nappia
 navigointia
 näytä
 näytetään
@@ -205,6 +217,7 @@ omistavan
 ongelmiin
 onnistui
 onnistunut
+onnistuu
 operaatio
 operaation
 osoite
@@ -237,13 +250,18 @@ polku
 postamista
 poudan
 projekteihin
+projekteja
 projekti
+projektia
+projektien
+projektien
 projektilla
 projektille
 projektilta
 projektin
 projektissa
 projektista
+projektit
 projektitunnisteet
 projektitunnisteille
 pudota
@@ -253,6 +271,13 @@ pyydetty
 pyydetyn
 pyyntö
 rajan
+rajattu
+rajatun
+rajoitettua
+rajoitettuihin
+rajoittamattomat
+rajoittamattomia
+rajoittamattomien
 rajoitteiden
 resurssienkäyttö
 resurssit
@@ -274,8 +299,12 @@ salausratkaisun
 salli
 sallittu
 selaamiseen
+selailla
+selailu
 selain
 selainta
+selatessa
+siirto
 sisään
 sisäänkirjauksen
 sisällön
@@ -336,6 +365,7 @@ tilan
 tilankäyttö
 tilapäinen
 tilapäisesti
+toiseen
 toteuttaa
 tueta
 tuettu
@@ -358,8 +388,10 @@ uusi
 uusia
 vaatii
 vähintään
+vaihto
 väliaikaiseen
 valikossa
+valinnan
 valinnat
 valitse
 valittu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- (GH #468) add support for project isolation for projects marked as restricted
+    - discovery for restricted projects pending, implemented logic only for now
+    - foced restricted mode can be configured on
+
+
 ## [v2.0.0]
 
 ### Added

--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -37,7 +37,14 @@ async def os_list_projects(request: aiohttp.web.Request) -> aiohttp.web.Response
     )
     # Filter out the tokens contained in session token
     return aiohttp.web.json_response(
-        [{"name": v["name"], "id": v["id"]} for _, v in session["projects"].items()]
+        [
+            {
+                "name": v["name"],
+                "id": v["id"],
+                "tainted": v["tainted"],
+            }
+            for _, v in session["projects"].items()
+        ]
     )
 
 

--- a/swift_browser_ui/ui/front.py
+++ b/swift_browser_ui/ui/front.py
@@ -22,6 +22,18 @@ async def browse(_: aiohttp.web.Request) -> aiohttp.web.FileResponse:
     )
 
 
+async def select(_: aiohttp.web.Request) -> aiohttp.web.FileResponse:
+    """Serve a project selection for users with tainted projects."""
+    return aiohttp.web.FileResponse(
+        str(setd["static_directory"]) + "/select.html",
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )
+
+
 async def index(
     request: typing.Optional[aiohttp.web.Request],
 ) -> typing.Union[aiohttp.web.Response, aiohttp.web.FileResponse]:

--- a/swift_browser_ui/ui/server.py
+++ b/swift_browser_ui/ui/server.py
@@ -20,13 +20,14 @@ import aiohttp_session.redis_storage
 
 import aioredis
 
-from swift_browser_ui.ui.front import index, browse, loginpassword
+from swift_browser_ui.ui.front import index, browse, loginpassword, select
 from swift_browser_ui.ui.login import (
     handle_login,
     handle_logout,
     sso_query_begin,
     sso_query_end,
     credentials_login_end,
+    handle_project_lock,
 )
 from swift_browser_ui.ui.api import (
     swift_get_metadata_container,
@@ -82,6 +83,7 @@ async def servinit(
     middlewares = [
         swift_browser_ui.ui.middlewares.error_middleware,
         swift_browser_ui.ui.middlewares.check_session_at,
+        swift_browser_ui.ui.middlewares.check_session_taintness,
     ]
     if inject_middleware:
         middlewares = middlewares + inject_middleware
@@ -136,6 +138,14 @@ async def servinit(
             # Route all URLs prefixed by /browse to the browser page, as this is
             # an spa
             aiohttp.web.get("/browse/{tail:.*}", browse),
+            aiohttp.web.get("/select", select),
+        ]
+    )
+
+    # Add lock routes
+    app.add_routes(
+        [
+            aiohttp.web.get("/lock/{project}", handle_project_lock),
         ]
     )
 

--- a/swift_browser_ui/ui/settings.py
+++ b/swift_browser_ui/ui/settings.py
@@ -70,6 +70,7 @@ setd: Dict[str, Union[str, int, None]] = {
     "has_trust": environ.get("BROWSER_START_HAS_TRUST", False),
     "set_origin_address": environ.get("BROWSER_START_SET_ORIGIN_ADDRESS", None),
     "os_user_domain": environ.get("OS_USER_DOMAIN_NAME", "Default"),
+    "force_restricted_mode": environ.get("SWIFT_UI_FORCE_RESTRICTED_MODE", False),
     "logfile": None,
     "port": 8080,
     "verbose": False,

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -300,6 +300,20 @@ let default_translations = {
         buildingIndex: "This project has a large number of objects. Please, " +
                        "wait while the search index is ready, and try again.",
       },
+      select: {
+        heading: "Select project for logging in",
+        description: "The user account used for logging in contains " +
+          "projects flagged as restricted. The interface scope is limited " +
+          "when a restricted project is opened, i.e. only the restricted " +
+          "project is visible during a restricted session. This means you " +
+          "cannot copy or move items across projects or view items in " +
+          "other projects available to you. Select a project you want to " +
+          "use from the following listing, after selection you will not be " +
+          "able to change the project without logging out. If you want to " +
+          "browse unrestricted projects, use the unrestricted projects " +
+          "button below.",
+        unrestricted: "All unrestricted projects",
+      },
     },
   },
   fi: {
@@ -593,6 +607,19 @@ let default_translations = {
         searchBy: "Etsi nimellä tai tägillä",
         buildingIndex: "Tässä projektissa on suuri määrä kohteita. Odota, " +
                        "kunnes hakuindeksi on valmis, ja yritä uudelleen.",
+      },
+      select: {
+        heading: "Valitse projekti kirjautuaksesi sisään",
+        description: "Käyttäjällä on pääsy rajoitettuihin projekteihin. " +
+          "Selatessa rajoitettua projektia käyttöliittymän pääsy on " +
+          "rajattu, eli vain rajatun projektin sisältö on näkyvissä. " +
+          "Tiedostojen kopiointi ja siirto projektista toiseen, ja " +
+          "muiden projektien sisällön selailu on estetty. Valitse " +
+          "projekti, jota haluat käyttää. Valinnan jälkeen projektin " +
+          "vaihto onnistuu vain kirjautumalla ulos. Mikäli haluat " + 
+          "selailla vain rajoittamattomia projekteja, paina " +
+          "rajoittamattomien projektien nappia alla.",
+        unrestricted: "Kaikki rajoittamattomat projektit",
       },
     },
   },

--- a/swift_browser_ui_frontend/src/entries/select.js
+++ b/swift_browser_ui_frontend/src/entries/select.js
@@ -1,0 +1,51 @@
+import Vue from "vue";
+import App from "@/pages/SelectPage.vue";
+import Buefy from "buefy";
+
+import getLangCookie from "@/common/conv";
+import translations from "@/common/lang";
+
+import { getProjects } from "@/common/api";
+
+// Import project css
+import "@/css/prod.scss";
+
+import VueI18n from "vue-i18n";
+
+Vue.use(VueI18n);
+Vue.use(Buefy);
+
+
+const i18n = new VueI18n({
+  locale: getLangCookie(),
+  messages: translations,
+});
+
+new Vue ({
+  i18n,
+  data: {
+    formname: "Token id:",
+    loginformname: "Openstack account:",
+    idb: true,
+    projects: [],
+    langs: [{ph: "In English", value: "en"}, {ph: "Suomeksi", value: "fi"}],
+  },
+  created() {
+    document.title = this.$t("message.program_name");
+    this.updateProjects();
+  },
+  methods: {
+    "updateProjects": function () {
+      getProjects().then(ret => this.projects = ret);
+    },
+    setCookieLang: function() {
+      const expiryDate = new Date();
+      expiryDate.setMonth(expiryDate.getMonth() + 1);
+      document.cookie = "OBJ_UI_LANG=" +
+                        i18n.locale +
+                        "; path=/; expires="
+                        + expiryDate.toUTCString();
+    },
+  },
+  ...App,
+}).$mount("#app");

--- a/swift_browser_ui_frontend/src/pages/SelectPage.vue
+++ b/swift_browser_ui_frontend/src/pages/SelectPage.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="selectpage">
+    <div class="content has-text-centered">
+      <h2>{{ $t("message.select.heading" ) }}</h2>
+      <p class="maintext">
+        {{ $t("message.select.description") }}
+      </p>
+      <p
+        v-for="project in projects.filter(pro => pro.tainted)"
+        :key="project.id"
+      >
+        <b-button
+          tag="a"
+          expanded
+          :href="'/lock/'.concat(project.id)"
+          size="is-large"
+          type="is-primary is-outlined"
+        >
+          {{ project.name }}
+        </b-button>
+      </p>
+      <p>
+        <b-button
+          tag="a"
+          expanded
+          href="/lock/none"
+          size="is-large"
+          type="is-primary is-outlined"
+        >
+          {{ $t("message.select.unrestricted" ) }}
+        </b-button>
+      </p>
+      <p>
+        <b-field class="locale-changed block center">
+          <b-select
+            v-model="$i18n.locale"
+            placeholder="Language"
+            icon="earth"
+            expanded
+            @input="setCookieLang ()"
+          >
+            <option
+              v-for="lang in langs"
+              :key="lang.value"
+              :value="lang.value"
+            >
+              {{ lang.ph }}
+            </option>
+          </b-select>
+        </b-field>
+      </p>
+    </div>
+  </div>
+</template>
+
+<style>
+html, body {
+  height: 100%;
+}
+.selectpage {
+  width: 40%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  align-content: center;
+  justify-content: center;;
+}
+.center {
+  width: 50%;
+  margin: auto;
+}
+</style>

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -17,6 +17,13 @@ module.exports = {  // eslint-disable-line
       title: "Swift browser UI",
       chunks: ["chunk-vendors", "chunk-common", "index"],
     },
+    select: {
+      entry: "src/entries/select.js",
+      template: "public/select.html",
+      filename: "select.html",
+      title: "Select a project to isolate",
+      chunks: ["chunk-vendors", "chunk-common", "select"],
+    },
     badrequest: {
       entry: "src/entries/badrequest.js",
       template: "public/index.html",

--- a/tests/common/mockups.py
+++ b/tests/common/mockups.py
@@ -32,12 +32,14 @@ class APITestBase(unittest.IsolatedAsyncioTestCase):
                 "name": "test-name-0",
                 "token": "test-token-0",
                 "endpoint": "https://test-endpoint-0/v1/AUTH_test-id-0",
+                "tainted": False,
             },
             "test-id-1": {
                 "id": "test-id-1",
                 "name": "test-name-1",
                 "token": "test-token-1",
                 "endpoint": "https://test-endpoint-1/v1/AUTH_test-id-1",
+                "tainted": False,
             },
         }
         self.aiohttp_session_get_session_mock = unittest.mock.AsyncMock()

--- a/tests/ui_unit/test_api.py
+++ b/tests/ui_unit/test_api.py
@@ -35,10 +35,12 @@ class APITestClass(tests.common.mockups.APITestBase):
                 {
                     "id": "test-id-0",
                     "name": "test-name-0",
+                    "tainted": False,
                 },
                 {
                     "id": "test-id-1",
                     "name": "test-name-1",
+                    "tainted": False,
                 },
             ]
         )

--- a/tests/ui_unit/test_login.py
+++ b/tests/ui_unit/test_login.py
@@ -197,6 +197,7 @@ class LoginTestClass(tests.common.mockups.APITestBase):
         """
         self.setd_mock["session_lifetime"] = 28800
         self.setd_mock["history_lifetime"] = 2592000
+        self.setd_mock["force_restricted_mode"] = False
         self.setd_mock["swift_endpoint_url"] = ("http://obj.exampleosep.com:443/v1",)
         patch1 = unittest.mock.patch(
             "swift_browser_ui.ui.login.setd",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Add generalized support for restricting project access. The UI backend now contains the logic to defer login process until a specific project is selected, if any of the projects is marked tainted. As there's not yet a set way to indicate a tainted project, this support is disabled by default as of now.

Tainted projects can be forced on for development or deployment purposes by setting the environment variable `SWIFT_UI_FORCE_RESTRICTED_MODE`. Setting this environment variable will taint all projects the user has access to, allowing only a single project to be browsed at a time.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* fixes #468 by adding possibility to restrict the user to a single project

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Add project tainting 
* Add tainted project check middleware to lock UI until taint flag is removed
* Add endpoint for locking the UI to a specific project
* Add inital frontend page for selecting the project when taint flag is set

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
