### PR TITLE
Hotfix/v2.0.0 regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #514) Fixed container and metadata updates
 
 ## [v2.0.1]
+
+### Fixed
+
 - Fix routing issues from trailing slash when adding project to container ACL.
+- Fix incorrect session fetch in backend when accessing objects owned by foreign projects
 
 ## [v2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #502) Items being removed from IndexedDB on network errors.
 - (GH #514) Fixed container and metadata updates
 
+## [v2.0.1]
+- Fix routing issues from trailing slash when adding project to container ACL.
+
 ## [v2.0.0]
 
 ### Added

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = f"{current_year}, CSC Developers"
 author = "CSC Developers"
 
 # The full version, including alpha/beta/rc tags
-version = release = "2.0.0"
+version = release = "2.0.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/swift_browser_ui/__init__.py
+++ b/swift_browser_ui/__init__.py
@@ -6,6 +6,6 @@ with the object storage.
 """
 
 __name__ = "swift_browser_ui"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "CSC Developers"
 __license__ = "MIT License"

--- a/swift_browser_ui/ui/_convenience.py
+++ b/swift_browser_ui/ui/_convenience.py
@@ -171,10 +171,12 @@ async def get_tempurl_key(request: aiohttp.web.Request) -> str:
 
 async def open_upload_runner_session(
     request: aiohttp.web.Request,
+    project: str = "",
 ) -> str:
     """Open an upload session to the token."""
     session = await aiohttp_session.get_session(request)
-    project = request.match_info["project"]
+    if not project:
+        project = request.match_info["project"]
     try:
         return session["projects"][project]["runner"]
     except KeyError:

--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -667,12 +667,17 @@ async def swift_download_shared_object(
         "API call for shared download runner "
         f"from {request.remote}, sess: {session} :: {time.ctime()}"
     )
+
+    project = ""
+    if "project" in request.query:
+        project = request.query["project"]
+
     path = (
         f"/{request.match_info['project']}/"
         + f"{request.match_info['container']}/"
         + request.match_info["object"]
     )
-    runner_id = await open_upload_runner_session(request)
+    runner_id = await open_upload_runner_session(request, project=project)
     signature = await sign(3600, path)
     path += (
         f"?session={runner_id}"
@@ -696,8 +701,13 @@ async def swift_download_container(
         "API call for container download runner from "
         f"{request.remote}, sess: {session} :: {time.ctime()}"
     )
+
+    project = ""
+    if "project" in request.query:
+        project = request.query["project"]
+
     path = f"/{request.match_info['project']}/" + f"{request.match_info['container']}"
-    runner_id = await open_upload_runner_session(request)
+    runner_id = await open_upload_runner_session(request, project=project)
     signature = await sign(3600, path)
     path += (
         f"?session={runner_id}"
@@ -748,7 +758,10 @@ async def get_upload_session(
         "API call for object upload runner info request from "
         f"{request.remote}, sess: {session} :: {time.ctime()}"
     )
-    runner_id = await open_upload_runner_session(request)
+    project = ""
+    if "project" in request.query:
+        project = request.query["project"]
+    runner_id = await open_upload_runner_session(request, project=project)
     path = f"/{request.match_info['project']}/{request.match_info['container']}"
     signature = await sign(3600, path)
     return aiohttp.web.json_response(

--- a/swift_browser_ui_frontend/package.json
+++ b/swift_browser_ui_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift_browser_ui_frontend_npm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode development",

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -255,7 +255,7 @@ export async function addAccessControlMeta(
   let aclURL = new URL(
     "/api/access/".concat(
       encodeURI(project), "/",
-      encodeURI(container), "/",
+      encodeURI(container),
     ),
     document.location.origin,
   );

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -421,16 +421,18 @@ export async function removeToken(
 
 export async function getUploadEndpoint(
   project,
+  owner,
   container,
 ) {
   // Fetch upload endpoint, session and signature information
   let fetchURL = new URL("/upload/".concat(
-    encodeURI(project),
+    encodeURI(owner),
     "/",
     encodeURI(container),
   ),
   document.location.origin,
   );
+  fetchURL.searchParams.append("project", project);
   let ret = await GET(fetchURL);
 
   if (ret.status != 200) {

--- a/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerDownloadLink.vue
@@ -63,6 +63,8 @@ export default {
             this.$route.params.owner,
             "/",
             this.$route.params.container,
+            "?project=",
+            this.$active.id,
           );
         }
         else {
@@ -79,6 +81,8 @@ export default {
             this.$props.project,
             "/",
             this.$props.container,
+            "?project=",
+            this.$active.id,
           );
         }
         else {

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -199,9 +199,26 @@ new Vue({
           },
         });
       }
+      return active;
     };
-    initialize().then(() => {
-      return;
+    initialize().then((ret) => {
+      if (this.$te("message.keys")) {
+        for (let item of Object.entries(this.$t("message.keys"))) {
+          let keyURL = new URL(
+            "/download/"
+            + item[1]["project"] + "/"
+            + item[1]["container"] + "/"
+            + item[1]["object"],
+            document.location.origin,
+          );
+          keyURL.searchParams.append("project", ret.id);
+          fetch(keyURL).then(resp => {
+            return resp.text();
+          }).then(resp => {
+            this.$store.commit("appendPubKey", resp);
+          });
+        }
+      }
     });
     fetch("/discover")
       .then((resp) => {
@@ -230,20 +247,6 @@ new Vue({
       this.containerSyncWrapper,
       10000,
     );
-    if (this.$te("message.keys")) {
-      for (let item of Object.entries(this.$t("message.keys"))) {
-        fetch(
-          "/download/"
-            + item[1]["project"] + "/"
-            + item[1]["container"] + "/"
-            + item[1]["object"],
-        ).then(resp => {
-          return resp.text();
-        }).then(resp => {
-          this.$store.commit("appendPubKey", resp);
-        });
-      }
-    }
   },
   methods: {
     dragHandler: function (e) {

--- a/swift_browser_ui_frontend/src/views/Upload.vue
+++ b/swift_browser_ui_frontend/src/views/Upload.vue
@@ -525,6 +525,7 @@ export default {
     aBeginUpload: async function (files) {
       // Upload files to the active container
       let uploadInfo = await getUploadEndpoint(
+        this.active.id,
         this.$route.params.owner ? this.$route.params.owner : this.active.id,
         this.$route.params.container,
       );


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Two regressions were found in the latest update. Session backend handled shared files incorrectly, trying to access them with credentials of the project in question, instead of the project user is using for browsing the files. A trailing slash in sharing routes broke sharing buckets.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Remove trailing slash in share routes
* Add project context awareness to front- and back-end to allow browsing objects owned by different projects with correct auth token
* Fix race condition in upload key fetch -> moved to be called after all projects are known

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
