### PR TITLE
Make project change reload the page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (GH #502) Items being removed from IndexedDB on network errors.
-- (GH #514) Fixed container and metadata updates
+- (GH #514) Fixed container and metadata updates.
 - (GH #547) Fixed upload button being enabled when there are no files to upload.
+- (GH #549) Fixed changing project keeps loading previous project data.
+- (GH #550) Fixed changing project shows container from previous project.
 
 ## [v2.0.1]
 

--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -412,7 +412,8 @@ async def swift_get_project_metadata(
             "X-Auth-Token": session["projects"][project]["token"],
         },
     ) as ret:
-        if ret.status != 204:
+        # Empty projects return 200, otherwise 204
+        if ret.status not in {200, 204}:
             raise aiohttp.web.HTTPUnauthorized(
                 reason="Project is not valid for Object Storage"
             )

--- a/swift_browser_ui_frontend/src/components/BrowserNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserNavbar.vue
@@ -29,12 +29,16 @@
             </a>
 
             <div class="navbar-dropdown">
-              <a
+              <router-link
                 v-for="item in projects"
                 :key="item.id"
+                :to="{
+                  name: 'ContainersView', 
+                  params: {user: uname, project: item.id}
+                }"
                 class="navbar-item"
-                @click="changeActive(item)"
-              ><span>{{ item.name }}</span></a>
+                @click.native.stop="changeActive(item)"
+              >{{ item.name }}</router-link>
             </div>
           </div>
           <div
@@ -62,7 +66,10 @@
           <div class="navbar-item">
             <div class="buttons">
               <router-link
-                :to="{name: 'DashboardView', params: {user: uname}}"
+                :to="{
+                  name: 'DashboardView', 
+                  params: {user: uname, project: active.id}
+                }"
                 :class="!($route.name == 'DashboardView') ? 
                   'button is-primary is-outlined' : 
                   'button is-primary has-text-light'"
@@ -165,17 +172,12 @@ export default {
         + expiryDate.toUTCString();
     },
     changeActive (item) {
-      this.$store.commit("setActive", item);
-      let newParams = Object.fromEntries(Object.entries(
-        this.$route.params,
-      ));
-      if (newParams.project != undefined) {
-        newParams.project = item.id;
+      if (item.id !== this.active.id){
+        this.$router.go({
+          name: "ContainersView", 
+          params: {user: this.uname, project: item.id},
+        });
       }
-      this.$router.push({
-        name: this.$route.name,
-        params: newParams,
-      });
     },
   },
 };

--- a/swift_browser_ui_frontend/src/components/BrowserNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserNavbar.vue
@@ -177,15 +177,6 @@ export default {
         params: newParams,
       });
     },
-    getProjectChangeURL ( newProject ) {
-      let rescopeURL = new URL(
-        "/login/rescope",
-        document.location.origin,
-      );
-      rescopeURL.searchParams.append( "project", newProject );
-      return rescopeURL.toString();        
-    },
-
   },
 };
 </script>

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -46,8 +46,6 @@ checkIDB().then(result => {
 
 window.onerror = function(error) { 
   if(DEV) console.log("Global error", error);
-  error.preventDefault();
-  error.stopPropagation();
 };
 window.addEventListener("unhandledrejection", function(event) {
   if(DEV) console.log("unhandledrejection", event);

--- a/swift_browser_ui_frontend/src/views/Dashboard.vue
+++ b/swift_browser_ui_frontend/src/views/Dashboard.vue
@@ -169,8 +169,10 @@ export default {
   },
   beforeMount(){
     // Fetch relevant things upon initializing the class instance
-    this.fetchMeta();
-    this.disable();
+    if (this.active.id) {
+      this.fetchMeta();
+      this.disable();
+    }
   },
   methods: {
     fetchMeta: function () {

--- a/tests/cypress/integration/browser.spec.js
+++ b/tests/cypress/integration/browser.spec.js
@@ -10,6 +10,11 @@ describe("Browse containers and test operations", function () {
   });
 
   it("should be able to filter table, adjust display containers per page and pagination", () => {
+    cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)
+    cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
+        .should('have.css', 'display', 'block')
+    cy.contains('service').click()
+    
     cy.get('[data-testid="containersPerPage"]').select('5 per page')
     cy.contains('1-5 / 15')
     cy.get('[data-testid="paginationSwitch"]').click()
@@ -61,6 +66,11 @@ describe("Browse containers and test operations", function () {
   })
 
   it("should display, add, remove container tags", () => {
+    cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)
+    cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
+        .should('have.css', 'display', 'block')
+    cy.contains('service').click()
+
     // container list loads with tags
     cy.get('tbody .tags .tag').should('have.length', 45)
     cy.get('tbody tr .tags').first().children('.tag').should('have.length', 3)
@@ -91,6 +101,11 @@ describe("Browse containers and test operations", function () {
   })
 
   it("should display, add, remove object tags", () => {
+    cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)
+    cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
+        .should('have.css', 'display', 'block')
+    cy.contains('service').click()
+
     cy.get('tbody tr td[data-label=Name]').first().dblclick()
 
     // object list loads with tags

--- a/tests/cypress/integration/userInfo.spec.js
+++ b/tests/cypress/integration/userInfo.spec.js
@@ -35,20 +35,23 @@ describe("Retrieve User information", function () {
 
     it("should login the user and switch to user infomation and retrieve correct data", () => {
         cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)
+        cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
+            .should('have.css', 'display', 'block')
+        cy.contains('service').click()
+        cy.contains('User information').invoke("attr", 'href').should("match", /browse\/swift\/[0-9a-f]{32}\/info/)
         cy.contains('User information').click()
         cy.location("pathname").should("match", /browse\/swift/)
         cy.contains('Buckets: 15')
     })
 
     it("should login to switch project and browser and view different information", () => {
-        cy.wait(1000)
-        cy.contains('User information').click()
+        cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)
         cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
             .should('have.css', 'display', 'block')
         cy.contains('swift-project').click()
+        cy.contains('User information').invoke("attr", 'href').should("match", /browse\/swift\/[0-9a-f]{32}\/info/)
+        cy.contains('User information').click()
         cy.contains('Buckets: 10')
-        cy.get('.navbar-dropdown').invoke('css', 'display', 'block')
-            .should('have.css', 'display', 'block')
         cy.location("pathname").should("match", /browse\/swift/)
         cy.contains('.buttons > .button','Browser').click()
         cy.location("pathname").should("match", /browse\/swift\/[0-9a-f]{32}/)


### PR DESCRIPTION
### Description


This always happened before the async updates, and is a simple way to
solve at least couple of new issues, with network requests from previous
project not being cancelled, and also container from previous project
was still visible after project change.
<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Fixes #549 
- Fixes #550

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Removed unused code
- Clicking on changing a project now refreshes the page while changing the project
- Use anchor link for project list dropdown
- Hopefully reduce flakiness in cypress

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
