### PR TITLE
Prevent unexpected errors in empty projects

### DIFF
--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -412,7 +412,8 @@ async def swift_get_project_metadata(
             "X-Auth-Token": session["projects"][project]["token"],
         },
     ) as ret:
-        if ret.status != 204:
+        # Empty projects return 200, otherwise 204
+        if ret.status not in {200, 204}:
             raise aiohttp.web.HTTPUnauthorized(
                 reason="Project is not valid for Object Storage"
             )

--- a/swift_browser_ui_frontend/src/views/Dashboard.vue
+++ b/swift_browser_ui_frontend/src/views/Dashboard.vue
@@ -169,8 +169,10 @@ export default {
   },
   beforeMount(){
     // Fetch relevant things upon initializing the class instance
-    this.fetchMeta();
-    this.disable();
+    if (this.active.id) {
+      this.fetchMeta();
+      this.disable();
+    }
   },
   methods: {
     fetchMeta: function () {


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
At least when running against a swift backend, empty projects return `HTTP 200` instead of the expected `HTTP 204`, and was causing a redirection to `/unauth`.

The other change prevents `HTTP 500` when project is not yet set in the `Dashboard.vue`.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- Also accept HTTP 200 from the backend when requesting project metadata
- Request project metadata only after `active` is set

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
