### PR TITLE
Not all paths should be proxied.

### DIFF
--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -1,12 +1,25 @@
+const proxyTo = `http://${process.env.BACKEND_HOST || "localhost"}:${process.env.BACKEND_PORT || "8080"}`;
+
 module.exports = {  // eslint-disable-line
   publicPath: "/static",
   devServer: {
-    // eslint-disable-next-line
-    proxy: `http://${process.env.BACKEND_HOST || "localhost"}:${process.env.BACKEND_PORT || "8080"}`,
-    hot: "only",
+    proxy: {
+      "/static":              {target: proxyTo},
+      "/api":                 {target: proxyTo},
+      "/discover":            {target: proxyTo},
+      "/login":               {target: proxyTo},
+      "/login/oidc":          {target: proxyTo},
+      "/login/oidc-redirect": {target: proxyTo},
+      "/login/credentials":   {target: proxyTo},
+      "/login/return":        {target: proxyTo},
+      "/login/rescope":       {target: proxyTo},
+      "/upload":              {target: proxyTo},
+      "/download":            {target: proxyTo},
+      "/sign":                {target: proxyTo},
+      "/replicate":           {target: proxyTo},
+    },
     client: {
-      // eslint-disable-next-line
-      webSocketURL: `ws://${process.env.BACKEND_HOST || "localhost"}:${process.env.BACKEND_PORT || "8080"}/ws`,
+      webSocketURL: `ws://localhost:${process.env.PORT}/ws`,
     },
   },
   pages: {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Some paths are handled in the frontend, and shouldn't be proxied,
so the proxied paths need to be set explicitly.

Also ws server was configured with backend server parameters, but
it should be configured with frontend parameters.

hot doesn't need to be set. It works like that by default.

The development server can be run with parameters, as
`PORT=8081 BACKEND_PORT=8001 npm --prefix swift_browser_ui_frontend/ run serve`
The default for `PORT` is `8080`, so it doesn't need to be set in that case.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Limit the URL paths that are proxied
- Fix ws server parameters

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
