### PR TITLE
docker with OIDC does need permission in app/

### DIFF
--- a/dockerfiles/Dockerfile-build-crypt
+++ b/dockerfiles/Dockerfile-build-crypt
@@ -141,7 +141,8 @@ COPY ./deploy/app.sh /app/app.sh
 
 RUN chmod +x /app/app.sh
 
-RUN adduser --disabled-password --no-create-home swiftui
+RUN adduser --disabled-password --no-create-home swiftui && \
+    chown -R swiftui:swiftui /app
 USER swiftui
 
 ENTRYPOINT ["/bin/sh", "-c", "/app/app.sh"]

--- a/dockerfiles/Dockerfile-build-crypt-devel
+++ b/dockerfiles/Dockerfile-build-crypt-devel
@@ -142,7 +142,8 @@ COPY ./deploy/app.sh /app/app.sh
 
 RUN chmod +x /app/app.sh
 
-RUN adduser --disabled-password --no-create-home swiftui
+RUN adduser --disabled-password --no-create-home swiftui && \
+    chown -R swiftui:swiftui /app
 USER swiftui
 
 ENTRYPOINT ["/bin/sh", "-c", "/app/app.sh"]

--- a/dockerfiles/Dockerfile-ui
+++ b/dockerfiles/Dockerfile-ui
@@ -51,7 +51,8 @@ COPY ./deploy/app.sh /app/app.sh
 RUN chmod +x /app/app.sh
 
 RUN addgroup -g 1001 swiftui && \
-    adduser -D -u 1001 --disabled-password --no-create-home -G swiftui swiftui
+    adduser -D -u 1001 --disabled-password --no-create-home -G swiftui swiftui && \
+    chown -R swiftui:swiftui /app
 
 USER swiftui
 

--- a/dockerfiles/Dockerfile-ui-devel
+++ b/dockerfiles/Dockerfile-ui-devel
@@ -51,7 +51,8 @@ COPY ./deploy/app.sh /app/app.sh
 
 RUN chmod +x /app/app.sh
 
-RUN adduser --disabled-password --no-create-home swiftui
+RUN adduser --disabled-password --no-create-home swiftui && \
+    chown -R swiftui:swiftui /app
 USER swiftui
 
 ENTRYPOINT ["/bin/sh", "-c", "/app/app.sh"]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Building docker images with OIDC support actually needs access to `app/` folder, as 
it creates files. I had removed it thinking that it was because of the certificate, which was then not included.

Follow up from #552.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- add chown to dockerfiles for building with OIDC  support

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
