### PR TITLE
Skip second login button click when first authentication used Haka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #514) Make user roles configurable.
 - (GH #546) Optional two-step login with OpenID Connect (OIDC) as the first step.
   - When OIDC is enabled, the index page is replaced with a new one, that uses CSCfi/csc-ui components.
+  - (GH #565) Skip second login button click when first authentication used Haka.
 
 ### Changed
 

--- a/swift_browser_ui/ui/login.py
+++ b/swift_browser_ui/ui/login.py
@@ -86,7 +86,7 @@ async def oidc_end(request: aiohttp.web.Request) -> aiohttp.web.Response:
         "state": oidc_result["state"],
         "access_token": oidc_result["token"],
     }
-    request.app["Log"].info(session["oidc"])
+    request.app["Log"].debug(session["oidc"])
 
     response = aiohttp.web.Response(
         status=302, headers={"Location": "/login"}, reason="Redirection to login"


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
There is a new OIDC claim which indicates which authentication method was chosen. It comes as `homeFederation` from the provider.

With this, it's possible to skip the second step login button click, when the first one used Haka, as the second step also uses Haka.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Closes #565 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
<!-- List changes made. -->

- Skip second login button click when first authentication used Haka

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
