### PR TITLE
Feature/folder tabs revert-revert

### DIFF
--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -75,6 +75,7 @@ julkiset
 julkisia
 kaikki
 kansio
+kansiot
 kansioille
 kansioina
 kanssa
@@ -263,6 +264,7 @@ projektilla
 projektille
 projektilta
 projektin
+projektiin
 projektissa
 projektista
 projektit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- (GH #638) Added tab based folder view in browse-route
 - (GH #596) Support link phrasing, icon and destination update in main navigation
 - (GH #577) Updated layout for top navigation
 - (GH #596) Project switcher with CSC Design system select components

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -62,6 +62,11 @@ let default_translations = {
       logOut: "Log Out",
       cscOrg: "CSC - IT Center For Science LTD",
       devel: "Developed by",
+      folderTabs: {
+        all: "All project's folders",
+        sharedFrom: "Shared from project",
+        sharedTo: "Shared to project",
+      },
       table: {
         name: "Name",
         objects: "Objects",
@@ -381,6 +386,11 @@ let default_translations = {
       logOut: "Kirjaudu ulos",
       cscOrg: "CSC – Tieteen Tietotekniikan Keskus Oy",
       devel: "kehittänyt",
+      folderTabs: {
+        all: "Kaikki projektin kansiot",
+        sharedFrom: "Projektista jaetut",
+        sharedTo: "Projektiin jaetut",
+      },
       table: {
         name: "Nimi",
         objects: "Objekteja",

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import Router from "vue-router";
 import DashboardView from "@/views/Dashboard.vue";
-import ContainersView from "@/views/Containers.vue";
+import FoldersView from "@/views/Folders.vue";
 import ObjectsView from "@/views/Objects.vue";
 import EditObjectView from "@/views/EditObject.vue";
 import SharedObjects from "@/views/SharedObjects";
@@ -23,12 +23,12 @@ export default new Router({
   routes: [
     {
       path: "/browse/:user/:project/sharing/to",
-      name: "SharedTo",
+      name: "SharingTo",
       component: SharedTo,
     },
     {
       path: "/browse/:user/:project/sharing/from",
-      name: "SharedFrom",
+      name: "SharingFrom",
       component: SharedFrom,
     },
     {
@@ -93,8 +93,18 @@ export default new Router({
     },
     {
       path: "/browse/:user/:project",
-      name: "ContainersView",
-      component: ContainersView,
+      name: "AllFolders",
+      component: FoldersView,
+    },
+    {
+      path: "/browse/:user/:project/shared/to",
+      name: "SharedTo",
+      component: FoldersView,
+    },
+    {
+      path: "/browse/:user/:project/shared/from",
+      name: "SharedFrom",
+      component: FoldersView,
     },
     {
       path: "/browse/:user/:project/:container",

--- a/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
@@ -83,7 +83,7 @@ export default {
       const item = event.target.value;
       if (item.id !== this.active.id){
         const navigationParams = {
-          name: "ContainersView", 
+          name: this.$router.name, 
           params: {user: this.uname, project: item.id},
         };
 

--- a/swift_browser_ui_frontend/src/components/BrowserUserMenu.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserUserMenu.vue
@@ -49,11 +49,11 @@ export default {
         },
         {
           label: this.$t("message.dashboard.browser"),
-          route: { name: "ContainersView" },
+          route: { name: "AllFolders" },
         },
         {
           label: this.$t("message.share.shared"), 
-          route: { name: "SharedTo" },
+          route: { name: "SharingTo" },
           rule: this.$store.state.client,
         },
         {

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -1,0 +1,79 @@
+<template>
+  <c-tab-buttons
+    :value="findActiveTab()"
+    :mandatory="true"
+    data-testid="folder-tabs"
+  >
+    <c-button
+      v-for="tab in tabs"
+      :key="tab.label"
+      @click="navigate(tab.route.name)"
+    >
+      {{ tab.label }}
+    </c-button>
+  </c-tab-buttons>
+</template>
+
+<script>
+export default {
+  name: "FolderTabs",
+  data: function() {
+    return {
+      tabs: [],
+      activeTab: 0,
+    };
+  },
+  computed: {
+    project () {
+      return this.$route.params.project;
+    },
+    user () {
+      return this.$route.params.user;
+    },
+    name () {
+      return this.$route.name;
+    },
+  },
+  created: function () {
+    this.setTabs();
+  },
+  methods: {
+    setTabs() {
+      this.tabs = [
+        {
+          label: this.$t("message.folderTabs.all"),
+          route: { name: "AllFolders" },
+        },
+        {
+          label: this.$t("message.folderTabs.sharedFrom"),
+          route: { name: "SharedTo" },
+        },
+        {
+          label: this.$t("message.folderTabs.sharedTo"), 
+          route: { name: "SharedFrom" },
+        },
+      ];
+    },
+    findActiveTab() {
+      const routes = this.tabs.flatMap(tab => tab.route.name);
+      return routes.indexOf(this.name);
+    },
+    navigate(routeName) {
+      if (this.name !== routeName) {
+        return this.$router.push({name: routeName ,params: {
+          user: this.user,
+          project: this.project,
+        }});
+      }
+    },
+  },
+};
+</script>
+
+
+<style scroped>
+c-tab-buttons {
+  display: block;
+  padding-bottom: 2rem;
+}
+</style>

--- a/swift_browser_ui_frontend/src/components/SharedMenu.vue
+++ b/swift_browser_ui_frontend/src/components/SharedMenu.vue
@@ -5,21 +5,21 @@
         icon="folder-account"
         tag="router-link"
         :label="$t('message.share.to_me')"
-        :to="{name :'SharedTo' ,params: {
+        :to="{name :'SharingTo' ,params: {
           user: user,
           project: project,
         }}"
-        :active="name == 'SharedTo' ? true : false"
+        :active="name == 'SharingTo' ? true : false"
       />
       <b-menu-item
         icon="share"
         tag="router-link"
         :label="$t('message.share.from_me')"
-        :to="{name: 'SharedFrom', params: {
+        :to="{name: 'SharingFrom', params: {
           user: user,
           project: project,
         }}"
-        :active="name == 'SharedFrom' ? true : false"
+        :active="name == 'SharingFrom' ? true : false"
       />
       <b-menu-item
         icon="folder-plus"

--- a/swift_browser_ui_frontend/src/components/SharedOutTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedOutTable.vue
@@ -1,7 +1,6 @@
 <template>
   <div 
     id="shared-out-table"
-    class="column"
   >
     <div class="field is-grouped">
       <p class="control">

--- a/swift_browser_ui_frontend/src/components/SharedTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedTable.vue
@@ -1,7 +1,6 @@
 <template>
   <div 
     id="shared-table"
-    class="column"
   >
     <b-field
       grouped

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -207,7 +207,7 @@ new Vue({
 
       if (document.location.pathname == "/browse") {
         this.$router.push({
-          name: "ContainersView",
+          name: "AllFolders",
           params: {
             project: active.id,
             user: user,
@@ -452,7 +452,7 @@ new Vue({
           retl.push({
             alias: this.$t("message.containers")
                    + this.$store.state.active.name || "",
-            address: {name: "ContainersView"},
+            address: {name: "AllFolders"},
           });
         }
       }

--- a/swift_browser_ui_frontend/src/pages/BrowserPage.vue
+++ b/swift_browser_ui_frontend/src/pages/BrowserPage.vue
@@ -133,6 +133,14 @@ html, body {
   color: $csc-primary;
 }
 
+.menu-icon {
+  font-size: 1.5rem;
+}
+
+.menu-active, .menu-icon {
+  color: $csc-primary;
+}
+
 .hero-body #login-center{
     padding: 30px 20px 20px 20px;
 }

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -6,7 +6,6 @@
     <b-field
       grouped
       group-multiline
-      class="groupControls"
     >
       <b-select
         v-model="perPage"
@@ -115,7 +114,6 @@
       </div>
     </b-field>
     <b-table
-      class="containerTable"
       focusable
       hoverable
       narrowed
@@ -340,6 +338,7 @@ import SearchResultItem from "@/components/SearchResultItem";
 import ContainerDownloadLink from "@/components/ContainerDownloadLink";
 import ReplicateContainerButton from "@/components/ReplicateContainer";
 import DeleteContainerButton from "@/components/ContainerDeleteButton";
+
 
 export default {
   name: "ContainersView",
@@ -583,11 +582,6 @@ export default {
 </script>
 
 <style scoped>
-.containerTable {
-  width: 90%;
-  margin-left: 5%;
-  margin-right: 5%;
-}
 .emptyTable {
   text-align: center;
   margin-top: 5%;

--- a/swift_browser_ui_frontend/src/views/Folders.vue
+++ b/swift_browser_ui_frontend/src/views/Folders.vue
@@ -1,0 +1,60 @@
+<template>
+  <c-flex class="container-box">
+    <FolderTabs />
+    <div
+      v-for="component of folderComponents"
+      :key="component.name"
+    >
+      <component
+        :is="component.type"
+        v-if="activeRouteName === component.name"
+      />
+    </div>
+  </c-flex>
+</template>
+
+<script>
+import FolderTabs from "@/components/FolderTabs.vue";
+import ContainersView from "@/views/Containers.vue";
+import SharedOutTable from "@/components/SharedOutTable.vue";
+import SharedTable from "@/components/SharedTable.vue";
+
+export default {
+  name: "FoldersView",
+  components: {
+    FolderTabs,
+    ContainersView,
+  },
+  data: function() {
+    return {
+      activeRouteName: "",
+      folderComponents: [
+        {type: ContainersView, name: "AllFolders"},
+        {type: SharedOutTable, name: "SharedFrom"},
+        {type: SharedTable, name: "SharedTo"},
+      ],
+    };
+  }, 
+  computed: {
+    name () {
+      return this.$route.name;
+    },
+  },
+  watch: {
+    "$route.name": function (name) {
+      this.activeRouteName = name;
+    },
+  },
+  created() {
+    this.activeRouteName = this.name;
+  },
+};
+</script>
+
+<style scoped>
+.container-box {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+</style>

--- a/tests/cypress/integration/browser.cy.js
+++ b/tests/cypress/integration/browser.cy.js
@@ -129,4 +129,15 @@ describe("Browse containers and test operations", function () {
     cy.get('button').contains('Save').click()
     cy.get('tbody tr .tags').first().children('.tag').should('have.length', 0)
   })
+
+  it("should navigate between all and shared folders with tab selectors", () => {
+    const testTabChange = (label, id) => {
+      cy.get('[data-testid="folder-tabs"]').find("c-button").contains(label).click()
+      cy.get(`#${id}`).should("be.visible")
+    }
+
+    testTabChange("Shared from", "shared-table")
+    testTabChange("Shared to", "shared-out-table")
+    testTabChange("All project's folders", "container-table")
+  })
 })

--- a/tests/cypress/integration/userInfo.cy.js
+++ b/tests/cypress/integration/userInfo.cy.js
@@ -45,6 +45,7 @@ describe("Retrieve User information", function () {
         cy.get('[data-testid="dashboard-loading-indicator"]').should("not.exist");
         cy.contains('Buckets: 15')
         cy.location("pathname").should("match", /browse\/swift/)
+
     })
 
     it("should login to switch project and browser and view different information", () => {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This PR introduces tab based view for folder components.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Closes #638 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Added parent component for dynamic folder component rendering
- Appended routes to match views for shared folders
- Created tab component for folder tabs
- Renamed `ContainersView` route to `AllFolders`
- Renamed routes for already existing sharing views so these don't interfere with new feature
- Added translations for new strings
- Removed css class names and handle block spacing in parent
- Added simple integration Cypress test for tab change
- Updated changelog
- Appended Finnish word list

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
