### PR TITLE
Tab based view for folders

### DIFF
--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -55,6 +55,7 @@ jaettuja
 jaetun
 jaetut
 jakamaan
+jakamasi
 jakaminen
 jakamista
 jako
@@ -313,6 +314,7 @@ selain
 selainta
 selatessa
 siirto
+sinulle
 sisään
 sisäänkirjauksen
 sisällön

--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -76,6 +76,7 @@ julkiset
 julkisia
 kaikki
 kansio
+kansiot
 kansioille
 kansioina
 kanssa
@@ -264,6 +265,7 @@ projektilla
 projektille
 projektilta
 projektin
+projektiin
 projektissa
 projektista
 projektit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (GH #651) Add modal for creating folder and ability to see project members in MyCSC
+- (GH #638) Added tab based folder view in browse-route
 - (GH #596) Support link phrasing, icon and destination update in main navigation
 - (GH #577) Updated layout for top navigation
 - (GH #596) Project switcher with CSC Design system select components

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -67,9 +67,9 @@ let default_translations = {
       cscOrg: "CSC - IT Center For Science LTD",
       devel: "Developed by",
       folderTabs: {
-        all: "All project's folders",
-        sharedFrom: "Shared from project",
-        sharedTo: "Shared to project",
+        all: "All folders",
+        sharedFrom: "Folders you have shared",
+        sharedTo: "Folders shared with you",
       },
       table: {
         name: "Name",
@@ -412,9 +412,9 @@ let default_translations = {
       cscOrg: "CSC – Tieteen Tietotekniikan Keskus Oy",
       devel: "kehittänyt",
       folderTabs: {
-        all: "Kaikki projektin kansiot",
-        sharedFrom: "Projektista jaetut",
-        sharedTo: "Projektiin jaetut",
+        all: "Kaikki kansiot",
+        sharedFrom: "Jakamasi kansiot",
+        sharedTo: "Sinulle jaetut kansiot",
       },
       table: {
         name: "Nimi",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -66,6 +66,11 @@ let default_translations = {
       logOut: "Log Out",
       cscOrg: "CSC - IT Center For Science LTD",
       devel: "Developed by",
+      folderTabs: {
+        all: "All project's folders",
+        sharedFrom: "Shared from project",
+        sharedTo: "Shared to project",
+      },
       table: {
         name: "Name",
         objects: "Objects",
@@ -406,6 +411,11 @@ let default_translations = {
       logOut: "Kirjaudu ulos",
       cscOrg: "CSC – Tieteen Tietotekniikan Keskus Oy",
       devel: "kehittänyt",
+      folderTabs: {
+        all: "Kaikki projektin kansiot",
+        sharedFrom: "Projektista jaetut",
+        sharedTo: "Projektiin jaetut",
+      },
       table: {
         name: "Nimi",
         objects: "Objekteja",

--- a/swift_browser_ui_frontend/src/common/router.js
+++ b/swift_browser_ui_frontend/src/common/router.js
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import Router from "vue-router";
 import DashboardView from "@/views/Dashboard.vue";
-import ContainersView from "@/views/Containers.vue";
+import FoldersView from "@/views/Folders.vue";
 import ObjectsView from "@/views/Objects.vue";
 import EditObjectView from "@/views/EditObject.vue";
 import SharedObjects from "@/views/SharedObjects";
@@ -22,12 +22,12 @@ export default new Router({
   routes: [
     {
       path: "/browse/:user/:project/sharing/to",
-      name: "SharedTo",
+      name: "SharingTo",
       component: SharedTo,
     },
     {
       path: "/browse/:user/:project/sharing/from",
-      name: "SharedFrom",
+      name: "SharingFrom",
       component: SharedFrom,
     },
     {
@@ -83,8 +83,18 @@ export default new Router({
     },
     {
       path: "/browse/:user/:project",
-      name: "ContainersView",
-      component: ContainersView,
+      name: "AllFolders",
+      component: FoldersView,
+    },
+    {
+      path: "/browse/:user/:project/shared/to",
+      name: "SharedTo",
+      component: FoldersView,
+    },
+    {
+      path: "/browse/:user/:project/shared/from",
+      name: "SharedFrom",
+      component: FoldersView,
     },
     {
       path: "/browse/:user/:project/:container",

--- a/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
@@ -1,10 +1,16 @@
 <template>
   <div id="secondary-navbar-wrapper">
-    <div id="secondary-navbar" class="navbar">
+    <div
+      id="secondary-navbar"
+      class="navbar"
+    >
       <div class="container is-fluid">
         <div class="navbar-menu">
           <div class="navbar-start">
-            <div v-if="multipleProjects" class="navbar-item">
+            <div
+              v-if="multipleProjects"
+              class="navbar-item"
+            >
               <c-select
                 v-bind="active"
                 c-control
@@ -18,7 +24,10 @@
                 @changeValue="changeActive($event)"
               />
             </div>
-            <div v-if="!multipleProjects" class="navbar-item">
+            <div
+              v-if="!multipleProjects"
+              class="navbar-item"
+            >
               {{ $t("message.currentProj") }}: &nbsp;<span>
                 {{ active.name }}
               </span>
@@ -27,9 +36,9 @@
           <div class="navbar-end">
             <div class="navbar-item">
               <c-button
-                @click="toggleCreateFolderModal"
                 outlined
                 data-testid="create-folder"
+                @click="toggleCreateFolderModal"
               >
                 {{ $t("message.createFolder") }}
               </c-button>

--- a/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
@@ -82,8 +82,8 @@ export default {
       const item = event.target.value;
       if (item.id !== this.active.id) {
         const navigationParams = {
-          name: "ContainersView",
-          params: { user: this.uname, project: item.id },
+          name: this.$router.name, 
+          params: {user: this.uname, project: item.id},
         };
 
         // Pushing to router before ´go´ method

--- a/swift_browser_ui_frontend/src/components/BrowserUserMenu.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserUserMenu.vue
@@ -49,11 +49,11 @@ export default {
         },
         {
           label: this.$t("message.dashboard.browser"),
-          route: { name: "ContainersView" },
+          route: { name: "AllFolders" },
         },
         {
           label: this.$t("message.share.shared"), 
-          route: { name: "SharedTo" },
+          route: { name: "SharingTo" },
           rule: this.$store.state.client,
         },
         {

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -48,11 +48,11 @@ export default {
           route: { name: "AllFolders" },
         },
         {
-          key: "message.folderTabs.sharedFrom",
+          key: "message.folderTabs.sharedTo",
           route: { name: "SharedTo" },
         },
         {
-          key: "message.folderTabs.sharedTo",
+          key: "message.folderTabs.sharedFrom",
           route: { name: "SharedFrom" },
         },
       ];

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -7,6 +7,7 @@
     <c-button
       v-for="tab in tabs"
       :key="tab.key"
+      class="tab-button"
       @click="navigate(tab.route.name)"
     >
       {{ $t(tab.key) }}
@@ -48,12 +49,12 @@ export default {
           route: { name: "AllFolders" },
         },
         {
-          key: "message.folderTabs.sharedTo",
-          route: { name: "SharedTo" },
-        },
-        {
           key: "message.folderTabs.sharedFrom",
           route: { name: "SharedFrom" },
+        },
+        {
+          key: "message.folderTabs.sharedTo",
+          route: { name: "SharedTo" },
         },
       ];
     },
@@ -74,5 +75,9 @@ export default {
 c-tab-buttons {
   display: block;
   padding-bottom: 2rem;
+}
+
+.tab-button {
+  flex-basis: 0;
 }
 </style>

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -1,0 +1,79 @@
+<template>
+  <c-tab-buttons
+    :value="findActiveTab()"
+    :mandatory="true"
+    data-testid="folder-tabs"
+  >
+    <c-button
+      v-for="tab in tabs"
+      :key="tab.label"
+      @click="navigate(tab.route.name)"
+    >
+      {{ tab.label }}
+    </c-button>
+  </c-tab-buttons>
+</template>
+
+<script>
+export default {
+  name: "FolderTabs",
+  data: function() {
+    return {
+      tabs: [],
+      activeTab: 0,
+    };
+  },
+  computed: {
+    project () {
+      return this.$route.params.project;
+    },
+    user () {
+      return this.$route.params.user;
+    },
+    name () {
+      return this.$route.name;
+    },
+  },
+  created: function () {
+    this.setTabs();
+  },
+  methods: {
+    setTabs() {
+      this.tabs = [
+        {
+          label: this.$t("message.folderTabs.all"),
+          route: { name: "AllFolders" },
+        },
+        {
+          label: this.$t("message.folderTabs.sharedFrom"),
+          route: { name: "SharedTo" },
+        },
+        {
+          label: this.$t("message.folderTabs.sharedTo"), 
+          route: { name: "SharedFrom" },
+        },
+      ];
+    },
+    findActiveTab() {
+      const routes = this.tabs.flatMap(tab => tab.route.name);
+      return routes.indexOf(this.name);
+    },
+    navigate(routeName) {
+      if (this.name !== routeName) {
+        return this.$router.push({name: routeName ,params: {
+          user: this.user,
+          project: this.project,
+        }});
+      }
+    },
+  },
+};
+</script>
+
+
+<style scroped>
+c-tab-buttons {
+  display: block;
+  padding-bottom: 2rem;
+}
+</style>

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -1,6 +1,6 @@
 <template>
   <c-tab-buttons
-    :value="findActiveTab()"
+    :value="activeTab"
     :mandatory="true"
     data-testid="folder-tabs"
   >
@@ -20,7 +20,6 @@ export default {
   data: function() {
     return {
       tabs: [],
-      activeTab: 0,
     };
   },
   computed: {
@@ -32,6 +31,10 @@ export default {
     },
     name () {
       return this.$route.name;
+    },
+    activeTab () {
+      const routes = this.tabs.flatMap(tab => tab.route.name);
+      return routes.indexOf(this.name);
     },
   },
   created: function () {
@@ -53,10 +56,6 @@ export default {
           route: { name: "SharedFrom" },
         },
       ];
-    },
-    findActiveTab() {
-      const routes = this.tabs.flatMap(tab => tab.route.name);
-      return routes.indexOf(this.name);
     },
     navigate(routeName) {
       if (this.name !== routeName) {

--- a/swift_browser_ui_frontend/src/components/FolderTabs.vue
+++ b/swift_browser_ui_frontend/src/components/FolderTabs.vue
@@ -6,10 +6,10 @@
   >
     <c-button
       v-for="tab in tabs"
-      :key="tab.label"
+      :key="tab.key"
       @click="navigate(tab.route.name)"
     >
-      {{ tab.label }}
+      {{ $t(tab.key) }}
     </c-button>
   </c-tab-buttons>
 </template>
@@ -44,22 +44,22 @@ export default {
     setTabs() {
       this.tabs = [
         {
-          label: this.$t("message.folderTabs.all"),
+          key: "message.folderTabs.all",
           route: { name: "AllFolders" },
         },
         {
-          label: this.$t("message.folderTabs.sharedFrom"),
+          key: "message.folderTabs.sharedFrom",
           route: { name: "SharedTo" },
         },
         {
-          label: this.$t("message.folderTabs.sharedTo"), 
+          key: "message.folderTabs.sharedTo",
           route: { name: "SharedFrom" },
         },
       ];
     },
     navigate(routeName) {
       if (this.name !== routeName) {
-        return this.$router.push({name: routeName ,params: {
+        return this.$router.push({name: routeName, params: {
           user: this.user,
           project: this.project,
         }});

--- a/swift_browser_ui_frontend/src/components/SharedMenu.vue
+++ b/swift_browser_ui_frontend/src/components/SharedMenu.vue
@@ -5,21 +5,21 @@
         icon="folder-account"
         tag="router-link"
         :label="$t('message.share.to_me')"
-        :to="{name :'SharedTo' ,params: {
+        :to="{name :'SharingTo' ,params: {
           user: user,
           project: project,
         }}"
-        :active="name == 'SharedTo' ? true : false"
+        :active="name == 'SharingTo' ? true : false"
       />
       <b-menu-item
         icon="share"
         tag="router-link"
         :label="$t('message.share.from_me')"
-        :to="{name: 'SharedFrom', params: {
+        :to="{name: 'SharingFrom', params: {
           user: user,
           project: project,
         }}"
-        :active="name == 'SharedFrom' ? true : false"
+        :active="name == 'SharingFrom' ? true : false"
       />
       <b-menu-item
         icon="folder-plus"

--- a/swift_browser_ui_frontend/src/components/SharedOutTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedOutTable.vue
@@ -1,7 +1,6 @@
 <template>
   <div 
     id="shared-out-table"
-    class="column"
   >
     <div class="field is-grouped">
       <p class="control">

--- a/swift_browser_ui_frontend/src/components/SharedTable.vue
+++ b/swift_browser_ui_frontend/src/components/SharedTable.vue
@@ -1,7 +1,6 @@
 <template>
   <div 
     id="shared-table"
-    class="column"
   >
     <b-field
       grouped

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -207,7 +207,7 @@ new Vue({
 
       if (document.location.pathname == "/browse") {
         this.$router.push({
-          name: "ContainersView",
+          name: "AllFolders",
           params: {
             project: active.id,
             user: user,
@@ -452,7 +452,7 @@ new Vue({
           retl.push({
             alias: this.$t("message.containers")
                    + this.$store.state.active.name || "",
-            address: {name: "ContainersView"},
+            address: {name: "AllFolders"},
           });
         }
       }

--- a/swift_browser_ui_frontend/src/pages/BrowserPage.vue
+++ b/swift_browser_ui_frontend/src/pages/BrowserPage.vue
@@ -133,6 +133,14 @@ html, body {
   color: $csc-primary;
 }
 
+.menu-icon {
+  font-size: 1.5rem;
+}
+
+.menu-active, .menu-icon {
+  color: $csc-primary;
+}
+
 .hero-body #login-center{
     padding: 30px 20px 20px 20px;
 }

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -65,7 +65,6 @@
       </b-autocomplete>
     </b-field>
     <b-table
-      class="containerTable"
       focusable
       hoverable
       narrowed
@@ -267,6 +266,7 @@ import ContainerDownloadLink from "@/components/ContainerDownloadLink";
 import ReplicateContainerButton from "@/components/ReplicateContainer";
 import DeleteContainerButton from "@/components/ContainerDeleteButton";
 import AddContainer from "@/views/AddContainer";
+
 
 export default {
   name: "ContainersView",
@@ -523,11 +523,6 @@ export default {
 </script>
 
 <style scoped>
-.containerTable {
-  width: 90%;
-  margin-left: 5%;
-  margin-right: 5%;
-}
 .emptyTable {
   text-align: center;
   margin-top: 5%;

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -1,20 +1,42 @@
 <template>
-  <div id="container-table" class="contents">
-    <c-modal v-control v-csc-model="openCreateFolderModal">
+  <div
+    id="container-table"
+    class="contents"
+  >
+    <c-modal
+      v-control
+      v-csc-model="openCreateFolderModal"
+    >
       <AddContainer />
     </c-modal>
-    <b-field grouped group-multiline class="groupControls">
+    <b-field
+      grouped
+      group-multiline
+      class="groupControls"
+    >
       <b-select
         v-model="perPage"
         data-testid="containersPerPage"
         :disabled="!isPaginated"
       >
-        <option value="5">5 {{ $t("message.table.pageNb") }}</option>
-        <option value="10">10 {{ $t("message.table.pageNb") }}</option>
-        <option value="15">15 {{ $t("message.table.pageNb") }}</option>
-        <option value="25">25 {{ $t("message.table.pageNb") }}</option>
-        <option value="50">50 {{ $t("message.table.pageNb") }}</option>
-        <option value="100">100 {{ $t("message.table.pageNb") }}</option>
+        <option value="5">
+          5 {{ $t("message.table.pageNb") }}
+        </option>
+        <option value="10">
+          10 {{ $t("message.table.pageNb") }}
+        </option>
+        <option value="15">
+          15 {{ $t("message.table.pageNb") }}
+        </option>
+        <option value="25">
+          25 {{ $t("message.table.pageNb") }}
+        </option>
+        <option value="50">
+          50 {{ $t("message.table.pageNb") }}
+        </option>
+        <option value="100">
+          100 {{ $t("message.table.pageNb") }}
+        </option>
       </b-select>
       <div class="control is-flex">
         <b-switch
@@ -56,8 +78,14 @@
             v-if="searchArray.length > 0 && searchArray[0].length > 1"
             class="media empty-search"
           >
-            <b-loading v-model="isSearching" :is-full-page="false" />
-            <div v-show="!isSearching" class="media-content">
+            <b-loading
+              v-model="isSearching"
+              :is-full-page="false"
+            />
+            <div
+              v-show="!isSearching"
+              class="media-content"
+            >
               {{ $t("message.search.empty") }}
             </div>
           </div>
@@ -81,7 +109,11 @@
       @keyup.native.enter="$router.push(getConAddr(selected['name']))"
       @keyup.native.space="$router.push(getConAddr(selected['name']))"
     >
-      <b-table-column sortable field="name" :label="$t('message.table.name')">
+      <b-table-column
+        sortable
+        field="name"
+        :label="$t('message.table.name')"
+      >
         <template #default="props">
           <span :class="props.row.count ? 'has-text-weight-bold' : ''">
             <b-icon
@@ -123,7 +155,11 @@
           {{ localHumanReadableSize(props.row.bytes) }}
         </template>
       </b-table-column>
-      <b-table-column field="functions" label="" width="150">
+      <b-table-column
+        field="functions"
+        label=""
+        width="150"
+      >
         <template #default="props">
           <div class="field has-addons">
             <p class="control">
@@ -141,7 +177,10 @@
                 :container="props.row.name"
               />
             </p>
-            <p v-if="!props.row.bytes" class="control">
+            <p
+              v-if="!props.row.bytes"
+              class="control"
+            >
               <b-button
                 v-if="selected == props.row"
                 type="is-primary"
@@ -164,7 +203,10 @@
                 {{ $t("message.share.share") }}
               </b-button>
             </p>
-            <p v-else class="control">
+            <p
+              v-else
+              class="control"
+            >
               <b-button
                 v-if="selected == props.row"
                 type="is-primary"
@@ -229,7 +271,11 @@
           </div>
         </template>
       </b-table-column>
-      <b-table-column field="dangerous" label="" width="75">
+      <b-table-column
+        field="dangerous"
+        label=""
+        width="75"
+      >
         <template #default="props">
           <DeleteContainerButton
             v-if="selected == props.row"

--- a/swift_browser_ui_frontend/src/views/Folders.vue
+++ b/swift_browser_ui_frontend/src/views/Folders.vue
@@ -1,0 +1,60 @@
+<template>
+  <c-flex class="container-box">
+    <FolderTabs />
+    <div
+      v-for="component of folderComponents"
+      :key="component.name"
+    >
+      <component
+        :is="component.type"
+        v-if="activeRouteName === component.name"
+      />
+    </div>
+  </c-flex>
+</template>
+
+<script>
+import FolderTabs from "@/components/FolderTabs.vue";
+import ContainersView from "@/views/Containers.vue";
+import SharedOutTable from "@/components/SharedOutTable.vue";
+import SharedTable from "@/components/SharedTable.vue";
+
+export default {
+  name: "FoldersView",
+  components: {
+    FolderTabs,
+    ContainersView,
+  },
+  data: function() {
+    return {
+      activeRouteName: "",
+      folderComponents: [
+        {type: ContainersView, name: "AllFolders"},
+        {type: SharedOutTable, name: "SharedFrom"},
+        {type: SharedTable, name: "SharedTo"},
+      ],
+    };
+  }, 
+  computed: {
+    name () {
+      return this.$route.name;
+    },
+  },
+  watch: {
+    "$route.name": function (name) {
+      this.activeRouteName = name;
+    },
+  },
+  created() {
+    this.activeRouteName = this.name;
+  },
+};
+</script>
+
+<style scoped>
+.container-box {
+  width: 90%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+</style>

--- a/tests/cypress/integration/browser.cy.js
+++ b/tests/cypress/integration/browser.cy.js
@@ -162,8 +162,8 @@ describe("Browse containers and test operations", function () {
       cy.get(`#${id}`).should("be.visible")
     }
 
-    testTabChange("Shared to", "shared-table")
-    testTabChange("Shared from", "shared-out-table")
-    testTabChange("All project's folders", "container-table")
+    testTabChange("Folders shared with you", "shared-table")
+    testTabChange("Folders you have shared", "shared-out-table")
+    testTabChange("All folders", "container-table")
   })
 })

--- a/tests/cypress/integration/browser.cy.js
+++ b/tests/cypress/integration/browser.cy.js
@@ -151,8 +151,19 @@ describe("Browse containers and test operations", function () {
     cy.get(".delete").each(el => {
       cy.get(".delete").first().click();
     });
-    cy.get(".taginput-container").children("span").should("have.length", 0);
-    cy.get("button").contains("Save").click();
-    cy.get("tbody tr .tags").first().children(".tag").should("have.length", 0);
-  });
-});
+    cy.get('.taginput-container').children('span').should('have.length', 0)
+    cy.get('button').contains('Save').click()
+    cy.get('tbody tr .tags').first().children('.tag').should('have.length', 0)
+  })
+
+  it("should navigate between all and shared folders with tab selectors", () => {
+    const testTabChange = (label, id) => {
+      cy.get('[data-testid="folder-tabs"]').find("c-button").contains(label).click()
+      cy.get(`#${id}`).should("be.visible")
+    }
+
+    testTabChange("Shared from", "shared-table")
+    testTabChange("Shared to", "shared-out-table")
+    testTabChange("All project's folders", "container-table")
+  })
+})

--- a/tests/cypress/integration/browser.cy.js
+++ b/tests/cypress/integration/browser.cy.js
@@ -162,8 +162,8 @@ describe("Browse containers and test operations", function () {
       cy.get(`#${id}`).should("be.visible")
     }
 
-    testTabChange("Shared from", "shared-table")
-    testTabChange("Shared to", "shared-out-table")
+    testTabChange("Shared to", "shared-table")
+    testTabChange("Shared from", "shared-out-table")
     testTabChange("All project's folders", "container-table")
   })
 })


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This PR introduces tab based view for folder components.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Closes #638 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Added parent component for dynamic folder component rendering
- Appended routes to match views for shared folders
- Created tab component for folder tabs
- Renamed `ContainersView` route to `AllFolders`
- Renamed routes for already existing sharing views so these don't interfere with new feature
- Added translations for new strings
- Removed css class names and handle block spacing in parent container in folders view
- Added simple integration Cypress test for tab change
- Updated changelog
- Appended Finnish word list

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests

