### PR TITLE
Prevent copying folder in place

### DIFF
--- a/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
@@ -35,8 +35,8 @@
             <c-button
               ghost
               class="navbar-item"
-              @click="copyProjectId"
               data-testid="copy-projectId"
+              @click="copyProjectId"
             >
               <i
                 slot="icon"

--- a/swift_browser_ui_frontend/src/components/FolderOptionsMenu.vue
+++ b/swift_browser_ui_frontend/src/components/FolderOptionsMenu.vue
@@ -111,7 +111,7 @@ export default {
       return this.active.id;
     },
     getContainer: function () {
-      return this.$props.container ? this.$props.container :
+      return this.props.row.name ? this.props.row.name :
         this.$route.params.container;
     },
   },

--- a/swift_browser_ui_frontend/src/views/Replicate.vue
+++ b/swift_browser_ui_frontend/src/views/Replicate.vue
@@ -97,12 +97,15 @@ export default {
         this.destination,
         this.$route.params.from,
         this.$route.params.container,
-      ).then(() => {
+      ).then(async () => {
         this.$buefy.toast.open({
           message: this.$t("message.copysuccess"),
           type: "is-success",
         });
-        this.$store.dispatch("updateContainers");
+        await this.$store.dispatch("updateContainers", {
+          projectID: this.$route.params.project,
+          signal: null,
+        });
         this.$router.go(-1);
       }).catch(() => {
         this.$buefy.toast.open({


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
`ReplicateContainer` view used old check for container existence before starting a copy, which meant you could copy folder in place overwriting the files and not actually copying them to a new container. Container existence check now rewritten to work with the IndexedDB approach of storing containers, plus it now checks against container specified in the URL.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
* Fixes #693 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Check copy destination container existence against IndexedDB instead of the old cache
* Check copy destination uniqueness based on the copy source container

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
