### PR TITLE
dependency auto-merge

### DIFF
--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -16,13 +16,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Wait other jobs are passed or failed
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'pip dependencies') || contains(github.event.pull_request.labels.*.name, 'github actions') || contains(github.event.pull_request.labels.*.name, 'npm dependencies') }}
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' }}
         uses: kachick/wait-other-jobs@v1
         timeout-minutes: 30
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if:  ${{ contains(github.event.pull_request.labels.*.name, 'pip dependencies') || contains(github.event.pull_request.labels.*.name, 'github actions') || contains(github.event.pull_request.labels.*.name, 'npm dependencies') }}
+        if:  ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' }}
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -16,13 +16,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Wait other jobs are passed or failed
-        if: ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' }}
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' }}
         uses: kachick/wait-other-jobs@v1
         timeout-minutes: 30
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if:  ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' }}
+        if:  ${{ steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'github_actions' }}
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Wait other jobs are passed or failed
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'pip dependencies') || contains(github.event.pull_request.labels.*.name, 'github actions') || contains(github.event.pull_request.labels.*.name, 'npm dependencies') }}
+        uses: kachick/wait-other-jobs@v1
+        timeout-minutes: 30
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if:  ${{ contains(github.event.pull_request.labels.*.name, 'pip dependencies') || contains(github.event.pull_request.labels.*.name, 'github actions') || contains(github.event.pull_request.labels.*.name, 'npm dependencies') }}
+        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v2
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION

### Description

<!-- Please include a summary of the change or any information deemed important. -->
dependabot creates a lot of dependency updates, auto-merge them if they have specific labels and all the tests pass

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

<!-- List changes made. -->

Added 2 new workflows:
- dependency review which checks dependencies for know vulnerabilities `moderate` or higher
- dependency auto merge, which has 2 steps first one waits for other actions to finish for 30 minutes, and the other merges the PR if all actions are successful. this is done only for PRs with labels `pip dependencies`, `npm dependencies`  and `github actions`, the `docker dependencies` is not added as that sometimes update python or npm versions and that creates issues 


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
From the tests this works about 95% of the time, sometimes it does not recognize the label and a `@dependabot recreate` is required