### PR TITLE
add owner awareness to object fetch

### DIFF
--- a/swift_browser_ui/ui/api.py
+++ b/swift_browser_ui/ui/api.py
@@ -175,6 +175,10 @@ async def swift_list_objects(request: aiohttp.web.Request) -> aiohttp.web.Stream
     client = request.app["api_client"]
     project = request.match_info["project"]
     container = request.match_info["container"]
+    if "owner" in request.query:
+        owner: str = request.query["owner"]
+    else:
+        owner = ""
 
     request.app["Log"].info(
         "API call for list objects from "
@@ -184,9 +188,11 @@ async def swift_list_objects(request: aiohttp.web.Request) -> aiohttp.web.Stream
     query = request.query.copy()
     query["format"] = "json"
 
+    endpoint = session["projects"][project]["endpoint"]
+
     # TODO: MOVE UNICODE NULL HANDLING TO FRONTEND
     async with client.get(
-        f"{session['projects'][project]['endpoint']}/{container}",
+        f"{endpoint.replace(project, owner) if owner else endpoint}/{container}",
         headers={
             "X-Auth-Token": session["projects"][project]["token"],
         },

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -128,6 +128,7 @@ export async function getObjects(
   marker = "",
   signal,
   shared = false,
+  owner = "",
 ) {
   // Fetch object listing for a container.
   let objUrl = new URL(
@@ -139,6 +140,9 @@ export async function getObjects(
   );
   if (marker) {
     objUrl.searchParams.append("marker", marker);
+  }
+  if (shared && (owner != "")) {
+    objUrl.searchParams.append("owner", owner);
   }
   let objects = await GET(objUrl, signal);
   if (objects.status == 200) {

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -369,7 +369,7 @@ const store = new Vuex.Store({
     },
     updateSharedObjects: async function (
       { commit, dispatch },
-      { project, container, signal },
+      { project, owner, container, signal },
     ) {
       commit("loading", true);
       let sharedObjects = [];
@@ -382,6 +382,7 @@ const store = new Vuex.Store({
           marker,
           signal,
           true,
+          owner,
         ).catch(() => {
           commit("loading", false);
           commit("updateObjects", []);


### PR DESCRIPTION
### Description

Quick fix to make object GET requests aware of the owner project. This isn't needed on Ceph, but current implementation has issues on real Openstack Swift used for testing.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

* re-introduce owner parameter to object fetches

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
