### PR TITLE
Make container table options aware of table status

### DIFF
--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -79,6 +79,7 @@
       </div>
 
       <c-menu
+        :key="optionsKey"
         :items.prop="tableOptions"
         options-testid="table-options-selector"
       >
@@ -128,6 +129,7 @@ export default {
       searchQuery: "",
       currentPage: 1,
       checkedRows: [],
+      optionsKey: 1,
       abortController: null,
       filteredObjects: [],
       inCurrentFolder: [],
@@ -593,6 +595,7 @@ export default {
           },
         },
       ];
+      this.optionsKey++;
     },
     setSelectionActionButtons() {
       this.selectionActionButtons = [

--- a/swift_browser_ui_frontend/src/views/Containers.vue
+++ b/swift_browser_ui_frontend/src/views/Containers.vue
@@ -17,6 +17,7 @@
       >
         <SearchBox />
         <c-menu
+          :key="optionsKey"
           :items.prop="tableOptions"
           options-testid="table-options-selector"
         >
@@ -60,6 +61,7 @@ export default {
       currentPage: 1,
       shareModalIsActive: false,
       showTags: true,
+      optionsKey: 1,
       abortController: null,
       containers: { value: [] },
     };
@@ -74,6 +76,9 @@ export default {
       },
       set() {},
     },
+    locale() {
+      return this.$i18n.locale;
+    },
   },
   watch: {
     active: function () {
@@ -82,18 +87,12 @@ export default {
     project: function () {
       this.fetchContainers();
     },
+    locale: function () {
+      this.updateTableOptions();
+    },
   },
   created() {
-    this.tableOptions = [
-      {
-        name: "Hide tags",
-        action: () => {this.hideTags = !(this.hideTags);},
-      },
-      {
-        name: "Hide pagination",
-        action: () => {this.disablePagination = !(this.disablePagination);},
-      },
-    ];
+    this.updateTableOptions();
   },
   beforeMount() {
     this.abortController = new AbortController();
@@ -106,6 +105,29 @@ export default {
     this.abortController.abort();
   },
   methods: {
+    updateTableOptions: function () {
+      this.tableOptions = [
+        {
+          name: this.hideTags
+            ? this.$t("message.tableOptions.showTags")
+            : this.$t("message.tableOptions.hideTags"),
+          action: () => {
+            this.hideTags = !(this.hideTags);
+            this.updateTableOptions();
+          },
+        },
+        {
+          name: this.disablePagination
+            ? this.$t("message.tableOptions.showPagination")
+            : this.$t("message.tableOptions.hidePagination"),
+          action: () => {
+            this.hideTags = !(this.hideTags);
+            this.updateTableOptions();
+          },
+        },
+      ];
+      this.optionsKey++;
+    },
     fetchContainers: async function () {
       if (
         this.active.id === undefined &&


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Table options for Object table are aware of current table status, displaying Show/Hide as they are supposed to. This implements the same functionality for the container table view.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Mirror `swift_browser_ui_frontend/src/components/ObjectTable.vue` table options functionality in `swift_browser_ui_frontend/src/views/Containers.vue` to make menu aware of current table status.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
