### PR TITLE
Fix for showing tags of objects inside a copied folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- (GH #788) Fix for objects of a copied folder rendering their tags correctly
 - (GH #781) Render full details of Folders you have shared and Folders shared with you
   - Show Folder status including Shared status, source project and date of sharing
   - Show tags for Folders and Objects inside them

--- a/swift_browser_ui/upload/replicate.py
+++ b/swift_browser_ui/upload/replicate.py
@@ -196,7 +196,7 @@ class ObjectReplicationProxy:
 
             # Copy over metadata headers
             for i in resp_g.headers:
-                if "Meta" in resp_g.headers[i]:
+                if "X-Object-Meta-Usertags" in i:
                     headers[i] = resp_g.headers[i]
 
             # If the object fits into the 5GiB limit imposed by Swift

--- a/swift_browser_ui_frontend/src/components/Containers.vue
+++ b/swift_browser_ui_frontend/src/components/Containers.vue
@@ -104,6 +104,7 @@ export default {
     isFolderCopied: function () {
       if (this.isFolderCopied) {
         this.fetchContainers();
+        this.$store.commit("setFolderCopiedStatus", false);
       }
     },
     locale: function () {


### PR DESCRIPTION
### Description

Tags of objects inside a copied folder can now be rendered correctly.

### Related issues
Fixes https://github.com/CSCfi/swift-browser-ui/issues/753

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Modified `replicate.py` to have correct filter for object's tags
- Updated Changelog

### Testing

- [x] Tests do not apply

