### PR TITLE
Fix for updating objects count and size when deleting objects inside folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- (GH #788) Fix for objects of a copied folder rendering their tags correctly
 - (GH #781) Render full details of Folders you have shared and Folders shared with you
   - Show Folder status including Shared status, source project and date of sharing
   - Show tags for Folders and Objects inside them
@@ -50,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (GH #827) Fixed for updating folder's items count and size when deleting objects inside it
+- (GH #788) Fixed for objects of a copied folder rendering their tags correctly
 - (GH #741) Fixed incorrect API token list logic causing an incorrect 404
 - (GH #780) Fixed tables' Display Options rendering the menu options correctly when data changed
 - (GH #502) Items being removed from IndexedDB on network errors.

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -364,7 +364,8 @@ export async function swiftDeleteObjects(
   let ret = await DELETE(
     fetchURL, JSON.stringify(objects),
   );
-  if (ret.status != 204) {
+
+  if (ret.status != 200) {
     throw new Error("Object / objects deletion not successful.");
   }
 }


### PR DESCRIPTION
### Description

Deleting objects inside a folder should now update the folder's items count and size correctly.

### Related issues
Fixes https://github.com/CSCfi/swift-browser-ui/issues/743

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Adapted fixes for **IndexedDB flakiness** in branch [release/v2.0.3-large-upload-release](https://github.com/CSCfi/swift-browser-ui/tree/release/v2.0.3-large-upload-release) for `store.js`
- Updated Changelog

### Testing

- [x] Tests do not apply


