### PR TITLE
retry on lazily loaded serviceworker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #827) Fixed for updating folder's items count and size when deleting objects inside it
 - (GH #788) Fixed for objects of a copied folder rendering their tags correctly
 - (GH #850) Call `refreshNoUpload` on file entry in upload modal
+- (GH #849) Fixed upload sometimes not starting due to lazily loaded service worker
 - (GH #741) Fixed incorrect API token list logic causing an incorrect 404
 - (GH #780) Fixed tables' Display Options rendering the menu options correctly when data changed
 - (GH #502) Items being removed from IndexedDB on network errors.

--- a/swift_browser_ui_frontend/src/components/UploadModal.vue
+++ b/swift_browser_ui_frontend/src/components/UploadModal.vue
@@ -556,7 +556,12 @@ export default {
       });
       upload.initServiceWorker();
       this.$store.commit("setCurrentUpload", upload);
-      delay(upload.cleanUp, 1500);
+      upload.cleanUp();
+      delay(() => {
+        if (this.$store.state.encryptedFile == "" && this.dropFiles.length) {
+          this.beginEncryptedUpload();
+        }
+      }, 1000);
       this.toggleUploadModal();
     },
   },


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Browsers sometimes decide to silently lazily load the registered upload service worker. This can cause a race condition, which requires retrying to start the upload process.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Retry uploading after it hasn't started for a period.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
