### PR TITLE
refresh noupload on file entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (GH #827) Fixed for updating folder's items count and size when deleting objects inside it
 - (GH #788) Fixed for objects of a copied folder rendering their tags correctly
+- (GH #850) Call `refreshNoUpload` on file entry in upload modal
 - (GH #741) Fixed incorrect API token list logic causing an incorrect 404
 - (GH #780) Fixed tables' Display Options rendering the menu options correctly when data changed
 - (GH #502) Items being removed from IndexedDB on network errors.

--- a/swift_browser_ui_frontend/src/components/UploadModal.vue
+++ b/swift_browser_ui_frontend/src/components/UploadModal.vue
@@ -343,6 +343,7 @@ export default {
     },
     dropFiles: function () {
       this.checkUploadSize();
+      this.refreshNoUpload();
     },
     transfer: function () {
       this.setFiles();


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Upload using default keys was not working in new modal due to the `refreshNoUpload` method not running on file changes. PR adds this call on change to files that are to be uploaded.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Call `refreshNoUpload` on upload modal file input

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
