### PR TITLE
kill upload sessions on finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (GH #851) Kill upload sessions upon finishing uploads to allow reuploading same files in all cases
 - (GH #884) Fixed multiple bugs
   - Redirected to AllFolders view whenever the selected project changes
   - Modified function and fixed notification for removing a shared permission

--- a/swift_browser_ui/ui/server.py
+++ b/swift_browser_ui/ui/server.py
@@ -61,6 +61,7 @@ from swift_browser_ui.ui.api import (
     swift_get_project_metadata,
     remove_project_container_acl,
     get_upload_session,
+    close_upload_session,
 )
 from swift_browser_ui.ui.health import handle_health_check
 from swift_browser_ui.ui.settings import setd
@@ -257,6 +258,7 @@ async def servinit(
     # Add upload routes
     app.add_routes(
         [
+            aiohttp.web.delete("/upload/{project}", close_upload_session),
             aiohttp.web.get("/upload/{project}/{container}", get_upload_session),
             aiohttp.web.get(
                 "/enupload/{project}/{container}/{object_name:.*}",

--- a/swift_browser_ui/upload/auth.py
+++ b/swift_browser_ui/upload/auth.py
@@ -10,6 +10,7 @@ import aiohttp.web
 
 import swift_browser_ui.common.types
 import swift_browser_ui.common.signature
+import swift_browser_ui.upload.common
 
 
 LOGGER = logging.getLogger(__name__)
@@ -75,6 +76,17 @@ async def handle_login(request: aiohttp.web.Request) -> aiohttp.web.StreamRespon
         return resp
     except KeyError:
         raise aiohttp.web.HTTPUnauthorized(reason="Login token or project missing")
+
+
+async def handle_logout(request: aiohttp.web.Request) -> aiohttp.web.Response:
+    """Close the specified upload session."""
+    try:
+        # We can safely ignore any errors in keys, since that just means the session
+        # doesn't exist
+        session_key: str = swift_browser_ui.upload.common.get_session_id(request)
+        request.app.pop(session_key)
+    finally:
+        return aiohttp.web.Response(status=204)
 
 
 @aiohttp.web.middleware

--- a/swift_browser_ui/upload/server.py
+++ b/swift_browser_ui/upload/server.py
@@ -17,6 +17,7 @@ import swift_browser_ui.common.common_util
 from swift_browser_ui.common.vault_client import VaultClient
 from swift_browser_ui.upload.auth import (
     handle_login,
+    handle_logout,
     handle_validate_authentication,
 )
 from swift_browser_ui.upload.api import (
@@ -60,12 +61,17 @@ async def servinit() -> aiohttp.web.Application:
     app["client"] = http_client
     app[VAULT_CLIENT] = VaultClient(http_client)
 
+    app.add_routes([aiohttp.web.get("/health", handle_health_check)])
+
     # Add auth related routes
     # Can use direct project post for creating a session, as it's intuitive
     # and POST upload against an account doesn't exist
-    app.add_routes([aiohttp.web.get("/health", handle_health_check)])
-
-    app.add_routes([aiohttp.web.post("/{project}", handle_login)])
+    app.add_routes(
+        [
+            aiohttp.web.post("/{project}", handle_login),
+            aiohttp.web.delete("/{project}", handle_logout),
+        ]
+    )
 
     # Add api routes
     app.add_routes(

--- a/swift_browser_ui_frontend/src/common/api.js
+++ b/swift_browser_ui_frontend/src/common/api.js
@@ -468,6 +468,22 @@ export async function getUploadEndpoint(
   return ret.json();
 }
 
+export async function killUploadEndpoint(
+  project,
+  owner,
+) {
+  let fetchURL = new URL(
+    `/upload/${encodeURI(owner)}`,
+    document.location.origin,
+  );
+  fetchURL.searchParams.append("project", project);
+  let ret = await DELETE(fetchURL);
+
+  if (ret.status != 204) {
+    throw new Error("Failed to kill upload session.");
+  }
+}
+
 export async function getUploadCryptedEndpoint(
   project,
   owner,

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -56,6 +56,7 @@ const store = new Vuex.Store({
     openCopyFolderModal: false,
     isFolderCopied: false,
     sourceProjectId: "",
+    uploadAbort: undefined,
   },
   mutations: {
     loading(state, payload) {
@@ -218,6 +219,16 @@ const store = new Vuex.Store({
       delete state.currentUpload;
       state.currentUpload = undefined;
       state.uploadNotification = false;
+    },
+    createCurrentUploadAbort(state) {
+      state.uploadAbort = new AbortController();
+    },
+    abortCurrentUpload(state) {
+      if (state.uploadAbort !== undefined) {
+        state.uploadAbort.abort();
+      }
+      delete state.uploadAbort;
+      state.uploadAbort = undefined;
     },
     toggleEditTagsModal(state, payload) {
       state.openEditTagsModal = payload;

--- a/swift_browser_ui_frontend/src/components/UploadModal.vue
+++ b/swift_browser_ui_frontend/src/components/UploadModal.vue
@@ -536,6 +536,12 @@ export default {
       if (this.pubkey.length > 0) {
         this.recvkeys = this.recvkeys.concat(this.pubkey);
       }
+      // Clean up old stale upload if exists
+      this.$store.commit("abortCurrentUpload");
+      this.$store.commit("eraseCurrentUpload");
+
+      // Create a fresh session from scratch
+      this.$store.commit("createCurrentUploadAbort");
       let upload = new EncryptedUploadSession(
         this.active,
         this.$route.params.owner ? this.$route.params.owner : this.active.id,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Stale upload sessions can lead to the file not reuploaded correctly. This PR fixes that by pruning the old sessions on upload finish.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Kill upload session when the upload process finishes

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
