### PR TITLE
Install python for Node 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (GH #853) Fix Node 18 needing python for npm install
 - (GH #827) Fixed for updating folder's items count and size when deleting objects inside it
 - (GH #788) Fixed for objects of a copied folder rendering their tags correctly
 - (GH #741) Fixed incorrect API token list logic causing an incorrect 404

--- a/dockerfiles/Dockerfile-build-crypt
+++ b/dockerfiles/Dockerfile-build-crypt
@@ -92,7 +92,7 @@ FROM node:18.12.1-alpine3.15 as FRONTEND
 ARG OIDC_ENABLED
 
 RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git\
+    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
     && rm -rf /var/cache/apk/*
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend

--- a/dockerfiles/Dockerfile-build-crypt-devel
+++ b/dockerfiles/Dockerfile-build-crypt-devel
@@ -92,7 +92,7 @@ FROM node:18.12.1-alpine3.15 as FRONTEND
 ARG OIDC_ENABLED
 
 RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git\
+    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
     && rm -rf /var/cache/apk/*
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend

--- a/dockerfiles/Dockerfile-ui
+++ b/dockerfiles/Dockerfile-ui
@@ -3,7 +3,7 @@ FROM node:18.12.1-alpine3.15 as FRONTEND
 ARG OIDC_ENABLED
 
 RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git\
+    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
     && rm -rf /var/cache/apk/*
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend

--- a/dockerfiles/Dockerfile-ui-devel
+++ b/dockerfiles/Dockerfile-ui-devel
@@ -1,7 +1,7 @@
 FROM node:18.12.1-alpine3.15 as FRONTEND
 
 RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git\
+    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
     && rm -rf /var/cache/apk/*
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Node 18, which we now use for building in place of node 16, apparently needs python present for installing some of the dependencies. As python is not present in the Node Docker image by default, it needs to be separately added.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Install python and pip in the UI image build stages

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
