### PR TITLE
Update csc-ui library to its latest version

### DIFF
--- a/swift_browser_ui_frontend/package-lock.json
+++ b/swift_browser_ui_frontend/package-lock.json
@@ -41,7 +41,7 @@
         "babel-eslint": "^10.1.0",
         "babel-jest": "^27.5.1",
         "cli-highlight": "^2.1.11",
-        "csc-ui": "^0.5.3",
+        "csc-ui": "^0.6.4",
         "csc-ui-vue-directive": "^0.0.4",
         "cypress": "^10.3.0",
         "eslint": "^8.26.0",
@@ -7078,9 +7078,9 @@
       }
     },
     "node_modules/csc-ui": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/csc-ui/-/csc-ui-0.5.3.tgz",
-      "integrity": "sha512-zrzk3tEesydciE5qrR19bxzCltNB2Su38DCCWXpoFoWMuuBYe3v190s4NyU+M9zOYTcAvBAWKdwaQ4ytqsHD6w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/csc-ui/-/csc-ui-0.6.4.tgz",
+      "integrity": "sha512-Zii/CQ2pzYyub/joUe6BdYdYJZ5n9jRvhUcBCQqbC/siO17yEF4sQfOqz6lsf+7UphFLwHsyzllpqXdxb1y1iA==",
       "dev": true,
       "dependencies": {
         "@mdi/js": "^6.7.96",
@@ -25895,9 +25895,9 @@
       }
     },
     "csc-ui": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/csc-ui/-/csc-ui-0.5.3.tgz",
-      "integrity": "sha512-zrzk3tEesydciE5qrR19bxzCltNB2Su38DCCWXpoFoWMuuBYe3v190s4NyU+M9zOYTcAvBAWKdwaQ4ytqsHD6w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/csc-ui/-/csc-ui-0.6.4.tgz",
+      "integrity": "sha512-Zii/CQ2pzYyub/joUe6BdYdYJZ5n9jRvhUcBCQqbC/siO17yEF4sQfOqz6lsf+7UphFLwHsyzllpqXdxb1y1iA==",
       "dev": true,
       "requires": {
         "@mdi/js": "^6.7.96",

--- a/swift_browser_ui_frontend/package.json
+++ b/swift_browser_ui_frontend/package.json
@@ -44,7 +44,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.5.1",
     "cli-highlight": "^2.1.11",
-    "csc-ui": "^0.5.3",
+    "csc-ui": "^0.6.4",
     "csc-ui-vue-directive": "^0.0.4",
     "cypress": "^10.3.0",
     "eslint-plugin-vue": "^9.6.0",


### PR DESCRIPTION
### Description

Updating `csc-ui` library to latest version `0.6.4` with many new fixes for `c-modal`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- c-modal content keyboard navigation is now prevented when it is closed
- c-modal and other components do not flash anymore in Firefox
- c-modal nudges when it is not dismissable and is clicked outside

