### PR TITLE
Fix global font setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #547) Fixed upload button being enabled when there are no files to upload.
 - (GH #549) Fixed changing project keeps loading previous project data.
 - (GH #550) Fixed changing project shows container from previous project.
+- Correctly set the global font to Museo sans
 
 ## [v2.0.1]
 

--- a/swift_browser_ui/upload/server.py
+++ b/swift_browser_ui/upload/server.py
@@ -122,7 +122,6 @@ async def servinit() -> aiohttp.web.Application:
 async def kill_client(app: aiohttp.web.Application) -> None:
     """Kill the app client session."""
     await app["client"].close()
-    await app[VAULT_CLIENT].close()
 
 
 def run_server(app: typing.Union[typing.Coroutine, aiohttp.web.Application]) -> None:

--- a/swift_browser_ui_frontend/src/components/CFooter.vue
+++ b/swift_browser_ui_frontend/src/components/CFooter.vue
@@ -96,7 +96,6 @@ export default {
 }
 
 .largetext{
-  font-family: var(--csc-font-family);
   font-style: normal;
   font-weight: 600;
   font-size: 16px;
@@ -104,7 +103,6 @@ export default {
   color: $csc-grey;
 }
 .smalltext{
-  font-family:  var(--csc-font-family);;
   font-style: normal;
   font-weight: 400;
   font-size: 14px;

--- a/swift_browser_ui_frontend/src/css/csc.scss
+++ b/swift_browser_ui_frontend/src/css/csc.scss
@@ -3,6 +3,9 @@
 
 @import "~bulma/sass/utilities/_all";
 
+@import "~csc-ui/dist/styles/variables.css";
+@import "~csc-ui/dist/styles/variables.scss";
+
 $csc-primary: #006778;
 $csc-primary-light: #c2dbdf;
 $csc-primary-lighter: #d8e8ea;
@@ -25,7 +28,7 @@ $csc-green: #51a808;
 $csc-orange: #ff5800;
 
 //Font Setting
-$csc-font-family: 'museo-sans';
+$family-primary: $csc-font-family;
 
 // Set bulma initial colors to be derived from
 // Not overriding black, black's fine as is

--- a/swift_browser_ui_frontend/src/pages/BrowserPage.vue
+++ b/swift_browser_ui_frontend/src/pages/BrowserPage.vue
@@ -93,7 +93,6 @@ html, body {
 #mainContainer {
   min-height: 100vh;
   position: relative;
-  font-family: var(--csc-font-family);
 }
 
 #subContainer {
@@ -102,7 +101,6 @@ html, body {
   display: flex;
   flex-direction: column;
   z-index: 1;
-  font-family: var(--csc-font-family);
 }
 
 .subContainer-additionalStyles {

--- a/swift_browser_ui_frontend/src/pages/LoginPage.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPage.vue
@@ -86,19 +86,16 @@
 }
 
 h2 {
-  font-family: 'Museo Sans';
   text-align: center;
 }
 
 .maintext {
-  font-family: 'Museo Sans';
   text-align: justify;
   line-height: 1.5;
 }
 
 #manlist {
   text-align: justify;
-  font-family:'Museo Sans';
   line-height: 1.4;
 }
 
@@ -119,7 +116,6 @@ a:hover {
 form {
   text-align: center;
   line-height: 2.5;
-  font-family: sans-serif;
 }
 
 #inputbox {


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
The default font shouldn't be set per element, as that will always cause issues. Instead, it should be set globally. As we use the Bulma CSS, overriding the default font sets the global font correctly.

The `csc-ui` library already has a variable for the font, and this changes use it. So future updates in the `csc-ui` font will propagate.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Fixed a minor bug in the Python code that was introduced in #864
- Import CSS variables `csc-ui`
- Set the default font to Museo sans by overriding the SCSS Bulma variable

### Testing

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
@ainoc 