### PR TITLE
Optimize docker image builds for subsequent builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved development workflow, and added development and testing instructions.
 - (GH #601) Implement new visual style using `csc-ui` in rest of the login and error pages
 - (GH #601) Add a language selector to login page menu bar, using `csc-ui`
+- (GH #920) Optimize docker builds, making them faster by leveraging more caching mechanisms and removing unnecessary package installation
 
 ### Fixed
 

--- a/dockerfiles/Dockerfile-build-crypt
+++ b/dockerfiles/Dockerfile-build-crypt
@@ -1,17 +1,25 @@
 # Build libsodium
 FROM emscripten/emsdk:latest AS SODIUM
 
-RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz \
-    && tar xvf libsodium-1.0.18-stable.tar.gz && cd libsodium-stable \
+ENV LIBSODIUM_VERSION 1.0.18-stable
+
+ADD https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz .
+
+RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
+    && cd libsodium-stable \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl
 FROM emscripten/emsdk:latest AS OPENSSL
 
-RUN wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz \
-    && bash -c 'if [[ $(sha256sum < openssl-1.1.1s.tar.gz) != *$(curl https://www.openssl.org/source/openssl-1.1.1s.tar.gz.sha256)* ]]; then echo $(sha256sum < openssl-1.1.1s.tar.gz) $(curl https://www.openssl.org/source/openssl-1.1.1s.tar.gz.sha256); echo Downloaded file checksum does not match. ; exit 1; fi' \
-    && tar xvf openssl-1.1.1s.tar.gz \
-    && cd openssl-1.1.1s \
+ENV OPENSSL_VERSION 1.1.1s
+
+ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz .
+ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256 .
+
+RUN bash -c 'if [[ $(sha256sum < openssl-${OPENSSL_VERSION}.tar.gz) != *$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256)* ]]; then echo $(sha256sum < openssl-${OPENSSL_VERSION}.tar.gz) $(curl https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256); echo Downloaded file checksum does not match. ; exit 1; fi' \
+    && tar xvf openssl-${OPENSSL_VERSION}.tar.gz \
+    && cd openssl-${OPENSSL_VERSION} \
     && emconfigure ./Configure linux-generic64 no-asm no-threads no-engine no-hw no-weak-ssl-ciphers no-dtls no-shared no-dso --prefix=/emsdk/upstream \
     && sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|g' Makefile \
     && sed -i '/^CFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
@@ -22,17 +30,21 @@ RUN wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz \
 # Build libcrypt4gh
 FROM emscripten/emsdk:latest AS LIBCRYPT4GH
 
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update -q \
+    && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
+    && apt-get install -yq autoconf
+
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstream/include/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
 
-RUN sudo apt-get update \
-    && sudo apt-get upgrade -y \
-    && sudo apt-get install -y autoconf
-
+ADD https://api.github.com/repos/cscfi/libcrypt4gh/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh
 
 # We'll skip linking libraries since emcc only produces static libraries
-# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
+# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
 RUN  export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && export LDFLAGS="-L/emsdk/upstream/lib" \
     && cd libcrypt4gh \
@@ -51,14 +63,16 @@ COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/
 COPY --from=OPENSSL /emsdk/upstream/include/ /emsdk/upstream/include/
 COPY --from=OPENSSL /emsdk/upstream/lib/ /emsdk/upstream/lib/
 
-RUN sudo apt-get update \
-    && sudo apt-get upgrade -y \
-    && sudo apt-get install -y autoconf build-essential
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update -q \
+    && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
+    && apt-get install -yq autoconf build-essential
 
+ADD https://api.github.com/repos/cscfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git
 
 # We'll skip linking libraries since emcc only produces static libraries
-# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
+# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
 RUN export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && export LDFLAGS="-L/emsdk/upstream/lib" \
     && cd libcrypt4gh-keys \
@@ -91,38 +105,31 @@ FROM node:18-alpine3.17 as FRONTEND
 
 ARG OIDC_ENABLED
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
-    && rm -rf /var/cache/apk/*
+COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
+COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    cd /root/swift_ui/swift_browser_ui_frontend \
+    && npm install
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
 
-RUN cd /root/swift_ui/swift_browser_ui_frontend \
-    && npm install
 RUN cd /root/swift_ui/swift_browser_ui_frontend \
     && OIDC_ENABLED=$OIDC_ENABLED npm run build
 
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_ui/requirements.txt
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
 COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.js
 COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.wasm
 
-RUN pip install --upgrade pip
-RUN pip install -r /root/swift_ui/requirements.txt
-RUN pip install /root/swift_ui
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
+    && pip install /root/swift_ui
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-build-crypt-devel
+++ b/dockerfiles/Dockerfile-build-crypt-devel
@@ -1,17 +1,25 @@
 # Build libsodium
 FROM emscripten/emsdk:latest AS SODIUM
 
-RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz \
-    && tar xvf libsodium-1.0.18-stable.tar.gz && cd libsodium-stable \
+ENV LIBSODIUM_VERSION 1.0.18-stable
+
+ADD https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz .
+
+RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
+    && cd libsodium-stable \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl
 FROM emscripten/emsdk:latest AS OPENSSL
 
-RUN wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz \
-    && bash -c 'if [[ $(sha256sum < openssl-1.1.1s.tar.gz) != *$(curl https://www.openssl.org/source/openssl-1.1.1s.tar.gz.sha256)* ]]; then echo $(sha256sum < openssl-1.1.1s.tar.gz) $(curl https://www.openssl.org/source/openssl-1.1.1s.tar.gz.sha256); echo Downloaded file checksum does not match. ; exit 1; fi' \
-    && tar xvf openssl-1.1.1s.tar.gz \
-    && cd openssl-1.1.1s \
+ENV OPENSSL_VERSION 1.1.1s
+
+ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz .
+ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256 .
+
+RUN bash -c 'if [[ $(sha256sum < openssl-${OPENSSL_VERSION}.tar.gz) != *$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256)* ]]; then echo $(sha256sum < openssl-${OPENSSL_VERSION}.tar.gz) $(curl https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256); echo Downloaded file checksum does not match. ; exit 1; fi' \
+    && tar xvf openssl-${OPENSSL_VERSION}.tar.gz \
+    && cd openssl-${OPENSSL_VERSION} \
     && emconfigure ./Configure linux-generic64 no-asm no-threads no-engine no-hw no-weak-ssl-ciphers no-dtls no-shared no-dso --prefix=/emsdk/upstream \
     && sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|g' Makefile \
     && sed -i '/^CFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
@@ -22,17 +30,21 @@ RUN wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz \
 # Build libcrypt4gh
 FROM emscripten/emsdk:latest AS LIBCRYPT4GH
 
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update -q \
+    && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
+    && apt-get install -yq autoconf
+
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstream/include/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
 
-RUN sudo apt-get update \
-    && sudo apt-get upgrade -y \
-    && sudo apt-get install -y autoconf
-
+ADD https://api.github.com/repos/cscfi/libcrypt4gh/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh
 
 # We'll skip linking libraries since emcc only produces static libraries
-# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
+# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
 RUN  export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && export LDFLAGS="-L/emsdk/upstream/lib" \
     && cd libcrypt4gh \
@@ -51,14 +63,16 @@ COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/
 COPY --from=OPENSSL /emsdk/upstream/include/ /emsdk/upstream/include/
 COPY --from=OPENSSL /emsdk/upstream/lib/ /emsdk/upstream/lib/
 
-RUN sudo apt-get update \
-    && sudo apt-get upgrade -y \
-    && sudo apt-get install -y autoconf build-essential
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update -q \
+    && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
+    && apt-get install -yq autoconf build-essential
 
+ADD https://api.github.com/repos/cscfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git
 
 # We'll skip linking libraries since emcc only produces static libraries
-# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
+# Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
 RUN export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && export LDFLAGS="-L/emsdk/upstream/lib" \
     && cd libcrypt4gh-keys \
@@ -91,38 +105,31 @@ FROM node:18-alpine3.17 as FRONTEND
 
 ARG OIDC_ENABLED
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
-    && rm -rf /var/cache/apk/*
+COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
+COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    cd /root/swift_ui/swift_browser_ui_frontend \
+    && npm install
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
 
-RUN cd /root/swift_ui/swift_browser_ui_frontend \
-    && npm install
 RUN cd /root/swift_ui/swift_browser_ui_frontend \
     && OIDC_ENABLED=$OIDC_ENABLED npm run build-devel
 
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_ui/requirements.txt
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
 COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.js
 COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.wasm
 
-RUN pip install --upgrade pip
-RUN pip install -r /root/swift_ui/requirements.txt
-RUN pip install /root/swift_ui
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
+    && pip install /root/swift_ui
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-request
+++ b/dockerfiles/Dockerfile-request
@@ -1,21 +1,13 @@
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_request/requirements.txt
 COPY setup.py /root/swift_request/setup.py
 COPY swift_browser_ui /root/swift_request/swift_browser_ui
 
-RUN pip install --upgrade pip\
-    && pip install -r /root/swift_request/requirements.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
     && pip install /root/swift_request
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-runner
+++ b/dockerfiles/Dockerfile-runner
@@ -1,21 +1,13 @@
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_upload_runner/requirements.txt
 COPY setup.py /root/swift_upload_runner/setup.py
 COPY swift_browser_ui /root/swift_upload_runner/swift_browser_ui
 
-RUN pip install --upgrade pip\
-    && pip install -r /root/swift_upload_runner/requirements.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
     && pip install /root/swift_upload_runner
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-sharing
+++ b/dockerfiles/Dockerfile-sharing
@@ -1,21 +1,13 @@
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_sharing/requirements.txt
 COPY setup.py /root/swift_sharing/setup.py
 COPY swift_browser_ui /root/swift_sharing/swift_browser_ui
 
-RUN pip install --upgrade pip\
-    && pip install -r /root/swift_sharing/requirements.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
     && pip install /root/swift_sharing
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-ui
+++ b/dockerfiles/Dockerfile-ui
@@ -2,35 +2,29 @@ FROM node:18-alpine3.17 as FRONTEND
 
 ARG OIDC_ENABLED
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
-    && rm -rf /var/cache/apk/*
+COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
+COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    cd /root/swift_ui/swift_browser_ui_frontend \
+    && npm install
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
 
 RUN cd /root/swift_ui/swift_browser_ui_frontend \
-    && npm install \
     && OIDC_ENABLED=$OIDC_ENABLED npm run build
 
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_ui/requirements.txt
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
 
-RUN pip install --upgrade pip && \
-    pip install -r /root/swift_ui/requirements.txt && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
     pip install /root/swift_ui
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/dockerfiles/Dockerfile-ui-devel
+++ b/dockerfiles/Dockerfile-ui-devel
@@ -1,37 +1,29 @@
 FROM node:18-alpine3.17 as FRONTEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git python3 \
-    && rm -rf /var/cache/apk/*
+ARG OIDC_ENABLED
+
+COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
+COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    cd /root/swift_ui/swift_browser_ui_frontend \
+    && npm install
 
 COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
 
-ARG OIDC_ENABLED
-
-RUN cd /root/swift_ui/swift_browser_ui_frontend \
-    && npm install
 RUN cd /root/swift_ui/swift_browser_ui_frontend \
     && OIDC_ENABLED=$OIDC_ENABLED npm run build-devel
 
 FROM python:3.10-alpine3.17 as BACKEND
 
-RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git \
-    && apk add --no-cache openssl-dev libffi-dev rust cargo \
-    && rm -rf /var/cache/apk/*
-
-COPY requirements.txt /root/swift_ui/requirements.txt
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
 
 RUN pip install --upgrade pip && \
-    pip install -r /root/swift_ui/requirements.txt
-RUN pip install /root/swift_ui
+    pip install /root/swift_ui
 
 FROM python:3.10-alpine3.17
-
-RUN apk add --no-cache --update bash
 
 LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
The Docker builds have been getting more complex, and taking longer time. This change makes subsequent builds faster by leveraging more of the caching systems available, and otherwise optimizing the build by not installing unnecessary packages.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
### Changes Made

<!-- List changes made. -->
- Don't install unnecessary packages
- Cache package installs and downloads
- Extract openssl and libsodium version strings for easier updates
- Re-build libcrypt4gh if the git remote was updated
- Separate NPM build from install, installing only if package versions have changed

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
- [X] Manual testing

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
