### PR TITLE
Fix 'Copy Share ID' tooltip formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #550) Fixed changing project shows container from previous project.
 - Correctly set the global font to Museo sans
 - Unify editing tags modal for objects and containers
+- Fix 'Share ID' tooltip formatting.
 
 ## [v2.0.1]
 

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -174,13 +174,13 @@ let default_translations = {
         share: "Share",
         share_id: "Share ID",
         share_id_tooltip:
-          "When another project wants share a folder " +
-          "with your project: Select this button and " +
-          "send Share ID (now copied in your cache) " +
-          "to the project’s member. " +
-          "When you want to share a folder with " +
-          "another project. Ask Share ID from " +
-          "another project’s member.",
+          "<strong>When another project wants to share a folder " +
+          "with your project</strong><br/>Select this button and " +
+          "send the Share ID (now copied in your cache) " +
+          "to the project's member.<br/><br/> " +
+          "<strong>When you want to share a folder with " +
+          "another project</strong><br/>Ask the Share ID from " +
+          "another project's member.",
         close: "Close",
         instructions: "Share ID instructions",
         close_instructions: "Close instructions",
@@ -640,11 +640,11 @@ let default_translations = {
         share: "Jaa",
         share_id: "Jaa tunnus",
         share_id_tooltip:
-          "Mikäli toisesta projektista halutaan jakaa kansio projektisi " +
-          "kanssa: Valitse tämä nappi ja lähetä Jakotunnus toisen " +
-          "projektin jäsenelle. Halutessasi jakaa kansion toisen " +
-          "projektin kanssa, pyydä jakotunnusta joltakin kyseisen " +
-          "projektin jäseneltä.",
+          "<strong>Mikäli toisesta projektista halutaan jakaa kansio " +
+          "projektisi kanssa</strong><br/>Valitse tämä nappi ja lähetä " +
+          "Jakotunnus toisen projektin jäsenelle.<br/><br/><strong>" +
+          "Halutessasi jakaa kansion toisen projektin kanssa</strong>" +
+          "<br/>Pyydä jakotunnusta joltakin kyseisen projektin jäseneltä.",
         close: "Kiinni",
         instructions: "Jaa tunnus ohjeet",
         close_instructions: "Sulje ohjeet",

--- a/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserSecondaryNavbar.vue
@@ -47,9 +47,12 @@
           <c-icon-button text>
             <i class="mdi mdi-information-outline" />
           </c-icon-button>
-          <span class="tooltip-content">
-            {{ $t("message.share.share_id_tooltip") }}
-          </span>
+          <!-- eslint-disable vue/no-v-html -->
+          <span 
+            class="tooltip-content"
+            v-html="$t('message.share.share_id_tooltip')"
+          />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
       </div>
       <c-toasts
@@ -210,6 +213,8 @@ export default {
     border: 1px solid $csc-primary;
     border-radius: 0.375rem;
     padding: 1rem;
+    font-size: 14px;
+    line-height: 16px;
 
     /* Position the tooltip */
     position: absolute;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Fix styling of the Share ID tooltip. Also fixed the spelling. It's a good idea to put sentences to a spellchecker, especially for English for e.g. languagetool.org.

![image](https://user-images.githubusercontent.com/93575941/214269772-45de0acb-677b-4a73-a23b-0212cab6e5c9.png)
![image](https://user-images.githubusercontent.com/93575941/214269900-65f3ee2e-6b67-476a-b06b-162340e56377.png)

Somehow on my computer, the bold font doesn't look as bold as in Figma, but the attributes are correct: `font-weight: 700`.

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Updated text string to include formatting
- Fix a couple of typos in the English string

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
@ainoc, @sampsapenna, please check if the formatting of the Finnish sentences are ok.