### PR TITLE
Bugfix/small window modal behaviour

### DIFF
--- a/swift_browser_ui_frontend/src/components/CopyFolderModal.vue
+++ b/swift_browser_ui_frontend/src/components/CopyFolderModal.vue
@@ -268,11 +268,24 @@ export default {
   max-height: 75vh;
 }
 
-@media screen and (max-height: 720px), (max-width: 992px ) {
-  .copy-folder {
-    max-height: 50vh;
+@media screen and (max-width: 773px), (max-height: 580px) {
+   .copy-folder {
+    top: -5rem;
   }
 }
+
+@media screen and (max-height: 580px) and (max-width: 773px), 
+(max-width: 533px) {
+  .copy-folder {
+    top: -9rem;
+  }
+}
+
+@media screen and (max-height: 580px) and (max-width: 533px) {
+  .copy-folder {
+    top: -13rem;
+   }
+ }
 
 c-card-content {
   color: var(--csc-dark-grey);


### PR DESCRIPTION
### Description

Copy folder modal does not shrink needlessly for smaller windows.

### Related issues
 "Fixes #910"

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Tests do not apply