### PR TITLE
Unify editing tags modal for objects and containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #549) Fixed changing project keeps loading previous project data.
 - (GH #550) Fixed changing project shows container from previous project.
 - Correctly set the global font to Museo sans
+- Unify editing tags modal for objects and containers
 
 ## [v2.0.1]
 

--- a/swift_browser_ui_frontend/src/common/globalFunctions.js
+++ b/swift_browser_ui_frontend/src/common/globalFunctions.js
@@ -8,11 +8,13 @@ export function toggleCreateFolderModal(folderName) {
   modifyBrowserPageStyles();
 }
 
-export function toggleEditTagsModal(object) {
+export function toggleEditTagsModal(objectName, containerName) {
   store.commit("toggleEditTagsModal", true);
-  const objectName = object.name.value;
   if (objectName) {
     store.commit("setObjectName", objectName);
+  }
+  if (containerName) {
+    store.commit("setFolderName", containerName);
   }
 }
 

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -193,10 +193,11 @@ export default {
                     size: "small",
                     title: "Edit tags",
                     path: mdiPencilOutline,
-                    onClick: ({ data }) => toggleEditTagsModal(data),
+                    onClick: ({ data }) => 
+                      toggleEditTagsModal(data.name.value, null),
                     onKeyUp: (event) => {
                       if(event.keyCode === 13) {
-                        toggleEditTagsModal(item.data);
+                        toggleEditTagsModal(item.data.name.value, null);
                       }
                     },
                   },

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -24,7 +24,7 @@ import {
   mdiFolder,
 } from "@mdi/js";
 import {
-  toggleCreateFolderModal,
+  toggleEditTagsModal,
   getSharingContainers,
   getSharedContainers,
   getAccessDetails,
@@ -282,7 +282,7 @@ export default {
                       },
                       {
                         name: this.$t("message.editTags"),
-                        action: () => toggleCreateFolderModal(item.name),
+                        action: () => toggleEditTagsModal(null, item.name),
                       },
                       {
                         name: this.$t("message.delete"),

--- a/swift_browser_ui_frontend/src/components/EditTagsModal.vue
+++ b/swift_browser_ui_frontend/src/components/EditTagsModal.vue
@@ -1,15 +1,14 @@
 <template>
   <c-card class="edit-tags">
     <h4 class="title is-4 has-text-dark">
-      {{ $t('message.objects.editObject') + object.name }}
+      {{ $t('message.editTags') }}
     </h4>
     <c-card-content>
       <b-field
         custom-class="has-text-dark"
-        :label="$t('message.tagName')"
       >
         <b-taginput
-          v-model="object.tags"
+          v-model="tags"
           ellipsis
           maxlength="20"
           has-counter
@@ -32,8 +31,8 @@
       </c-button>
       <c-button
         size="large"
-        @click="saveTags"
-        @keyup.enter="saveTags"
+        @click="isObject ? saveObjectTags() : saveContainerTags()"
+        @keyup.enter="isObject ? saveObjectTags() : saveContainerTags()"
       >
         {{ $t("message.save") }}
       </c-button>
@@ -44,17 +43,22 @@
 <script>
 import {
   updateObjectMeta,
+  updateContainerMeta,
 } from "@/common/api";
 import {
   taginputConfirmKeys,
   getTagsForObjects,
+  getTagsForContainer,
 } from "@/common/conv";
 
 export default {
   name: "EditTagsModal",
   data() {
     return {
-      object: {id: 0, name: "", tags: []},
+      container: null,
+      object: null,
+      tags: [],
+      isObject: false,
       taginputConfirmKeys,
     };
   },
@@ -64,55 +68,79 @@ export default {
         ? this.$store.state.selectedObjectName
         : "";
     },
+    selectedFolderName() {
+      return this.$store.state.selectedFolderName.length > 0
+        ? this.$store.state.selectedFolderName
+        : "";
+    },
   },
   watch: {
     selectedObjectName: function () {
       if (this.selectedObjectName && this.selectedObjectName.length > 0) {
+        this.isObject = true;
         this.getObject();
+      }
+    },
+    selectedFolderName: function () {
+      if (this.selectedFolderName && this.selectedFolderName.length > 0) {
+        this.isObject = false;
+        this.getContainer();
       }
     },
   },
   methods: {
     getObject: async function () {
+      this.container = await this.$store.state.db.containers.get({
+        projectID: this.$route.params.project,
+        name: this.$route.params.container,
+      });
       if (this.$route.name === "SharedObjects") {
-        this.container.name = this.$route.params.container;
-        this.object.name = this.selectedObjectName;
         this.$store.state.objectCache.map(obj => {
-          if (obj.name === this.object.name) {
-            this.object.tags = obj.tags;
+          if (obj.name === this.selectedObjectName) {
+            this.tags = obj.tags;
           }
         });
       } else {
-        this.container = await this.$store.state.db.containers.get({
-          projectID: this.$route.params.project,
-          name: this.$route.params.container,
-        });
         this.object = await this.$store.state.db.objects.get({
           containerID: this.container.id,
           name: this.selectedObjectName,
         });
+        if (!this.object.tags.length) {
+          const tags = await getTagsForObjects(
+            this.$route.params.project,
+            this.container.name,
+            [this.selectedObjectName],
+          );
+          this.tags = tags[0][1] || [];
+        } else {
+          this.tags = this.object.tags;
+        }
       }
-
-      if (!this.object.tags.length) {
-        const tags = await getTagsForObjects(
+    },
+    getContainer: async function () {
+      this.container = await this.$store.state.db.containers.get({
+        projectID: this.$route.params.project,
+        name: this.selectedFolderName,
+      });
+      if (!this.container.tags) {
+        this.tags = await getTagsForContainer(
           this.$route.params.project,
           this.container.name,
-          [this.object.name],
         );
-        this.tags = tags[0][1] || [];
       } else {
-        this.tags = this.object.tags;
+        this.tags = this.container.tags;
       }
     },
     toggleEditTagsModal: function () {
       this.$store.commit("toggleEditTagsModal", false);
       this.$store.commit("setObjectName", "");
+      this.$store.commit("setFolderName", "");
     },
-    saveTags: function () {
+    saveObjectTags: function () {
       let objectMeta = [
         this.object.name,
         {
-          usertags: this.object.tags.join(";"),
+          usertags: this.tags.join(";"),
         },
       ];
       updateObjectMeta(
@@ -123,10 +151,28 @@ export default {
         if (this.$route.name !== "SharedObjects") {
           await this.$store.state.db.objects
             .where(":id").equals(this.object.id)
-            .modify({tags: this.object.tags});
+            .modify({tags: this.tags});
         }
+        // FIXME: Looks like it's missing to save SharedObject tags
         this.toggleEditTagsModal();
       });
+    },
+    saveContainerTags: function () {
+      const tags = this.tags;
+      const containerName = this.container.name;
+      let meta = {
+        usertags: tags.join(";"),
+      };
+      updateContainerMeta(this.$route.params.project, containerName, meta)
+        .then(async () => {
+          await this.$store.state.db.containers
+            .where({
+              projectID: this.$route.params.project,
+              name: containerName,
+            })
+            .modify({ tags });
+        });
+      this.toggleEditTagsModal();
     },
   },
 };


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
When making the change to edit tags with a modal, only the tag editor for objects was changed. Editing tags for a container (folder) still used the same editor as the create folder modal. So the design was not the same.

This change makes both container and object tags editor use the same modal, according to the proposed design.

![image](https://user-images.githubusercontent.com/93575941/214591556-fe423db4-afa7-498a-b0f0-5b39ad400123.png)


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- https://github.com/CSCfi/swift-browser-ui/pull/748
- #724

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
<!-- List changes made. -->
- Moved the container tag editing functionality from the create folder modal to the edit tag modal

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
