### PR TITLE
Bugfix/sort shared status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #549) Fixed changing project keeps loading previous project data.
 - (GH #550) Fixed changing project shows container from previous project.
 - Correctly set the global font to Museo sans
+- (GL #27) Fixed the sorting of `Shared status` table column.
 
 ## [v2.0.1]
 

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -321,9 +321,25 @@ export default {
         itemCount: this.conts.length,
       };
     },
-    onSort(event) {
+    async onSort(event) {
       this.sortBy = event.detail.sortBy;
       this.sortDirection = event.detail.direction;
+
+      if (this.sortBy === "sharing") {
+        const sharingContainers = await getSharingContainers(this.active.id);
+        const sharedContainers = await getSharedContainers(this.active.id);
+
+        let allSharing = this.conts.map(x => sharingContainers.includes(x.name)
+          ? this.$t("message.table.sharing") : "");
+        let allShared = this.conts.map(x => 
+          sharedContainers.some(cont => cont.container === x.name)
+            ? this.$t("message.table.shared") : "");
+
+        let combined = allSharing.map((value, idx) => 
+          value !== "" ? value : allShared[idx]);
+        this.conts.forEach((cont, idx) => (cont.sharing = combined[idx]));
+      }
+      
       sortObjects(this.conts, this.sortBy, this.sortDirection);
     },
     setHeaders() {


### PR DESCRIPTION
### Description

Sorting column `Shared status` works now.
`sharing` field did not exist in this.conts, which is why sorting did nothing. This data is now added each time sorting `Shared status` is requested.

### Related issues
"Fixes gitlab issue #27."

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Tests do not apply

