### PR TITLE
Use `sh` for deployment scripts

### DIFF
--- a/deploy/app-request.sh
+++ b/deploy/app-request.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 THE_HOST=${HOST:="0.0.0.0"}
 THE_PORT=${PORT:="9091"}

--- a/deploy/app-runner.sh
+++ b/deploy/app-runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 THE_HOST=${HOST:="0.0.0.0"}
 THE_PORT=${PORT:="9092"}

--- a/deploy/app-sharing.sh
+++ b/deploy/app-sharing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 THE_HOST=${HOST:="0.0.0.0"}
 THE_PORT=${PORT:="9090"}

--- a/deploy/app.sh
+++ b/deploy/app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 THE_HOST=${HOST:="0.0.0.0"}
 THE_PORT=${PORT:="8080"}


### PR DESCRIPTION
### Description

Use `sh` for deployment scripts.

So that the docker image doesn't need Bash.
