### PR TITLE
Fix libupload path in dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly set the global font to Museo sans
 - Unify editing tags modal for objects and containers
 - Fix 'Share ID' tooltip formatting.
+- Libupload path in docker files
 
 ## [v2.0.1]
 

--- a/dockerfiles/Dockerfile-build-crypt
+++ b/dockerfiles/Dockerfile-build-crypt
@@ -122,8 +122,8 @@ FROM python:3.10-alpine3.17 as BACKEND
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
-COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.js
-COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.wasm
+COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/libupload.js
+COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/libupload.wasm
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \

--- a/dockerfiles/Dockerfile-build-crypt-devel
+++ b/dockerfiles/Dockerfile-build-crypt-devel
@@ -122,8 +122,8 @@ FROM python:3.10-alpine3.17 as BACKEND
 COPY setup.py /root/swift_ui/setup.py
 COPY swift_browser_ui /root/swift_ui/swift_browser_ui
 COPY --from=FRONTEND /root/swift_ui/swift_browser_ui_frontend/dist /root/swift_ui/swift_browser_ui_frontend/dist
-COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.js
-COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/sw/libupload.wasm
+COPY --from=WASMCRYPT /src/src/libupload.js /root/swift_ui/swift_browser_ui_frontend/dist/libupload.js
+COPY --from=WASMCRYPT /src/src/libupload.wasm /root/swift_ui/swift_browser_ui_frontend/dist/libupload.wasm
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
The path for libupload had been changed, but the docker files were not updated. This change fixes that.
