### PR TITLE
Allow adding commit hash and url to footer in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #565) Skip second login button click when first authentication used Haka.
 - (GH #599) Add support for streaming uploads allowing > 1GiB files encrypted uploads
   - Also fixes some bugs related to encrypted upload engine and repeatability
+- Add git commit version and link to footer
 
 ### Changed
 

--- a/dockerfiles/Dockerfile-build-crypt-devel
+++ b/dockerfiles/Dockerfile-build-crypt-devel
@@ -41,7 +41,7 @@ COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstr
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
 
 ADD https://api.github.com/repos/cscfi/libcrypt4gh/compare/main...HEAD /dev/null
-RUN git clone https://github.com/CSCfi/libcrypt4gh
+RUN git clone --single-branch https://github.com/CSCfi/libcrypt4gh
 
 # We'll skip linking libraries since emcc only produces static libraries
 # Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
@@ -69,7 +69,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     && apt-get install -yq autoconf build-essential
 
 ADD https://api.github.com/repos/cscfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
-RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git
+RUN git clone --single-branch https://github.com/CSCfi/libcrypt4gh-keys.git
 
 # We'll skip linking libraries since emcc only produces static libraries
 # Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)
@@ -105,6 +105,9 @@ FROM node:18-alpine3.17 as FRONTEND
 
 ARG OIDC_ENABLED
 
+RUN --mount=type=cache,target=/var/cache/apk/ \
+    apk add git
+
 COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
 COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
 
@@ -112,7 +115,7 @@ RUN --mount=type=cache,target=/root/.npm \
     cd /root/swift_ui/swift_browser_ui_frontend \
     && npm install
 
-COPY swift_browser_ui_frontend /root/swift_ui/swift_browser_ui_frontend
+COPY . /root/swift_ui/
 
 RUN cd /root/swift_ui/swift_browser_ui_frontend \
     && OIDC_ENABLED=$OIDC_ENABLED npm run build-devel
@@ -131,7 +134,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 FROM python:3.10-alpine3.17
 
-LABEL maintainer "CSC Developers"
+LABEL maintainer="CSC Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.vcs-url="https://github.com/CSCfi/swift-browser-ui"
 

--- a/dockerfiles/Dockerfile-ui-devel
+++ b/dockerfiles/Dockerfile-ui-devel
@@ -2,6 +2,9 @@ FROM node:18-alpine3.17 as FRONTEND
 
 ARG OIDC_ENABLED
 
+RUN --mount=type=cache,target=/var/cache/apk/ \
+    apk add git
+
 COPY swift_browser_ui_frontend/package.json /root/swift_ui/swift_browser_ui_frontend/package.json
 COPY swift_browser_ui_frontend/package-lock.json /root/swift_ui/swift_browser_ui_frontend/package-lock.json
 
@@ -25,7 +28,7 @@ RUN pip install --upgrade pip && \
 
 FROM python:3.10-alpine3.17
 
-LABEL maintainer "CSC Developers"
+LABEL maintainer="CSC Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.vcs-url="https://github.com/CSCfi/swift-browser-ui"
 

--- a/swift_browser_ui_frontend/src/components/CFooter.vue
+++ b/swift_browser_ui_frontend/src/components/CFooter.vue
@@ -19,6 +19,18 @@
                 {{ $t("message.footerMenu.serviceProvider") }}
               </a>
             </div>
+            <div 
+              v-if="dev" 
+              class="row navbar-item smalltext"
+            >
+              <a
+                class="linktext"
+                target="_blank"
+                :href="gitLink"
+              >
+                {{ gitVersion }}
+              </a>
+            </div>
           </div>        
         </div>
     
@@ -53,9 +65,17 @@
 </template>
 
 <script>
+import { DEV } from "@/common/conv";
 
 export default {
   name:"CFooter",
+  data: function() {
+    return {
+      dev: DEV,
+      gitVersion: process.env.VUE_APP_GIT_VERSION || "Version not set",
+      gitLink: process.env.VUE_APP_GIT_LINK || "#",
+    };
+  },
 };
 </script>
 

--- a/swift_browser_ui_frontend/vue.config.js
+++ b/swift_browser_ui_frontend/vue.config.js
@@ -1,3 +1,25 @@
+if (process.env.NODE_ENV === "development") {
+  const { execSync } = require("child_process");
+  const shell = (cmd) => execSync(cmd, {encoding: "utf8"}).trim();
+
+  try {
+    const branch = shell("git branch --show-current");
+    const version = shell("git describe --always --long --tags");
+    const hash = shell("git rev-parse HEAD");
+    const url = "https://github.com/CSCfi/swift-browser-ui/commit/";
+
+    process.env.VUE_APP_GIT_VERSION = `${branch} | ${version}`;
+    process.env.VUE_APP_GIT_LINK = url + hash;
+
+    console.log(process.env.VUE_APP_GIT_VERSION);
+    console.log(process.env.VUE_APP_GIT_LINK);
+  }
+  catch(error){
+    console.log("Failed to get version from git");
+    console.log(error);
+  }
+}
+
 const proxyTo = `http://${process.env.BACKEND_HOST || "localhost"}:${process.env.BACKEND_PORT || "8080"}`;
 const oidcEnabled = process.env.OIDC_ENABLED === "True";
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Add new fields to the footer that are only visible in dev mode. The values are extrated with `git` command when building in development mode, e.g. `npm run build-devel`.

![image](https://user-images.githubusercontent.com/93575941/215765679-265c6c46-b729-4109-9d61-d1151030d66b.png)

The version string follows the [`git describe` command](https://git-scm.com/docs/git-describe#_examples).
So in `feature/footer-version | v2.0.0-607-gcaf95d5d`

- `feature/footer-version` is the branch name
- `v2.0.0` indicates the git tag for the release version;
- `607` is the number of commits since the tagged commit;
- `gcaf95d5d` is the shortened commit hash (after removing `g`, so `caf95d5d`)

You can see the commit with `git show caf95d5d`

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Add a git branch, version and link to the footer, which is only visible in dev mode

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
