### PR TITLE
Fix hiding the pagination of data tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unify editing tags modal for objects and containers
 - Fix 'Share ID' tooltip formatting.
 - Libupload path in docker files
+- Fix hiding the pagination of data tables
 
 ## [v2.0.1]
 

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -6,6 +6,7 @@
     :headers.prop="hideTags ?
       headers.filter(header => header.key !== 'tags'): headers"
     :pagination.prop="disablePagination ? null : paginationOptions"
+    :hide-footer="disablePagination"
     :footer-options.prop="footerOptions"
     :no-data-text="$t('message.emptyContainer')"
     :sort-by="sortBy"

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -5,6 +5,7 @@
     :headers.prop="hideTags ?
       headers.filter(header => header.key !== 'tags'): headers"
     :pagination.prop="disablePagination ? null : paginationOptions"
+    :hide-footer="disablePagination"
     :footer-options.prop="footerOptions"
     :no-data-text="getEmptyText()"
     :sort-by="sortBy"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
I don't know if hiding the pagination broke with `csc-ui` update, or not. But there's a change in https://github.com/CSCfi/csc-ui/pull/74 which adds a new feature to hide the data table footer, and this change makes use of it.

Updated the code to use the feature of hiding the data table footer.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Updated the code to hide pagination

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
