### PR TITLE
use the same naming scheme db name

### DIFF
--- a/README-request.md
+++ b/README-request.md
@@ -9,7 +9,6 @@ machine in port 5432. If a database is not run on the local machine, the
 relevant information on the database can be provided with the following
 environment variables:
 
-* `REQUEST_DB_POSTGRES`; if found in environment, uses PostgreSQL.
 * `REQUEST_DB_PASSWORD`; **REQUIRED**: The password used for connecting to the
   database.
 * `REQUEST_DB_USER`; **DEFAULT**: request; The user used for the database

--- a/README-sharing.md
+++ b/README-sharing.md
@@ -23,7 +23,7 @@ production is PostgreSQL.
 
 The PostgreSQL implementation can be enabled via environment variables,
 that are
-* `SHARING_DB_POSTGRES`; if found in environment, uses PostgreSQL.
+
 * `SHARING_DB_PASSWORD`; **REQUIRED**: The password used for connecting to the
   database.
 * `SHARING_DB_USER`; **DEFAULT**: sharing; The user used for the database

--- a/swift_browser_ui/request/db.py
+++ b/swift_browser_ui/request/db.py
@@ -32,7 +32,7 @@ class DBConn:
                     host=os.environ.get("REQUEST_DB_HOST", "localhost"),
                     port=int(os.environ.get("REQUEST_DB_PORT", 5432)),
                     ssl=os.environ.get("REQUEST_DB_SSL", "prefer"),
-                    database=os.environ.get("REQUEST_DB_DATABASE", "swiftrequest"),
+                    database=os.environ.get("REQUEST_DB_NAME", "swiftrequest"),
                     min_size=os.environ.get("REQUEST_DB_MIN_CONNECTIONS", 0),
                     max_size=os.environ.get("REQUEST_DB_MAX_CONNECTIONS", 49),
                     timeout=os.environ.get("REQUEST_DB_TIMEOUT", 120),


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
had a small typo in https://github.com/CSCfi/swift-browser-ui/pull/956, this should fix it and standardize the `*_DB_*` env vars used

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->



### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->
- `REQUEST_DB_DATABASE` is now `REQUEST_DB_NAME`
- fix typo in docs for env var not used

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
