### PR TITLE
add env vars for redis sentinel 

### DIFF
--- a/.github/config/.env.test
+++ b/.github/config/.env.test
@@ -3,6 +3,13 @@ SWIFT_UI_REDIS_PASSWORD=
 SWIFT_UI_REDIS_PORT=6379
 SWIFT_UI_REDIS_HOST=localhost
 
+# Redis Sentinel configuration for HA Redis
+# this is for a Redis Sentinel that does not require password
+# instead it will forward auth to Redis
+# SWIFT_UI_REDIS_SENTINEL_HOST=
+# SWIFT_UI_REDIS_SENTINEL_PORT=26379
+# SWIFT_UI_REDIS_SENTINEL_MASTER=mymaster
+
 SWIFT_UI_FRONTEND_ALLOW_HOSTS=auto
 SWIFT_UI_TLS_PORT=8081
 SWIFT_UI_TLS_HOST=localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Also fixes some bugs related to encrypted upload engine and repeatability
 - Add git commit version and link to footer
 - Add option to specify database port and SSL mode for request and sharing DB connections
+- Add option to specify Redis Sentinel connection parameters for redis configured with Sentinel
 
 ### Changed
 

--- a/swift_browser_ui/ui/server.py
+++ b/swift_browser_ui/ui/server.py
@@ -19,6 +19,7 @@ import aiohttp_session
 import aiohttp_session.redis_storage
 
 import aioredis
+import aioredis.sentinel
 
 from oidcrp.rp_handler import RPHandler
 
@@ -103,16 +104,33 @@ async def servinit(
     app = aiohttp.web.Application()  # type: ignore
 
     # Initialize aiohttp_session
-    redis_creds = ""
+    sentinel_url = str(os.environ.get("SWIFT_UI_REDIS_SENTINEL_HOST", ""))
+    # we make this str to make it easier to check if exists
+    sentinel_port = str(os.environ.get("SWIFT_UI_REDIS_SENTINEL_PORT", ""))
+    sentinel_master = os.environ.get("SWIFT_UI_REDIS_SENTINEL_MASTER", "mymaster")
+
     redis_user = str(os.environ.get("SWIFT_UI_REDIS_USER", ""))
     redis_password = str(os.environ.get("SWIFT_UI_REDIS_PASSWORD", ""))
-    if redis_user and redis_password:
-        redis_creds = f"{redis_user}:{redis_password}@"
-    redis_port = str(os.environ.get("SWIFT_UI_REDIS_PORT", ""))
-    if redis_port:
-        redis_port = f":{redis_port}"
-    redis_host = str(os.environ.get("SWIFT_UI_REDIS_HOST", "localhost"))
-    redis = aioredis.from_url(f"redis://{redis_creds}{redis_host}{redis_port}")
+
+    redis: aioredis.Redis
+    if sentinel_url and sentinel_port:
+        # we forward the auth to redis so no need for auth on sentinel
+        sentinel = aioredis.sentinel.Sentinel([(str(sentinel_url), int(sentinel_port))])
+
+        redis = sentinel.master_for(
+            service_name=sentinel_master,
+            redis_class=aioredis.Redis,
+            password=redis_password,
+            username=redis_user,
+        )
+    else:
+        redis_port = str(os.environ.get("SWIFT_UI_REDIS_PORT", ""))
+        redis_host = str(os.environ.get("SWIFT_UI_REDIS_HOST", "localhost"))
+
+        redis_creds = ""
+        if redis_user and redis_password:
+            redis_creds = f"{redis_user}:{redis_password}@"
+        redis = aioredis.from_url(f"redis://{redis_creds}{redis_host}:{redis_port}")
     storage = aiohttp_session.redis_storage.RedisStorage(
         redis,
         cookie_name="SWIFT_UI_SESSION",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- add option to configure Redis Sentinel for discovering redis in master/slave configuration
  - `SWIFT_UI_REDIS_SENTINEL_HOST`
  - `SWIFT_UI_REDIS_SENTINEL_PORT`
  - `SWIFT_UI_REDIS_SENTINEL_MASTER` - name of the master in the configuration
### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
