### PR TITLE
Make footer stick to bottom in large screens on login pages

### DIFF
--- a/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
+++ b/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
@@ -45,7 +45,8 @@
 <style>
 c-main {
   height: unset;
-  min-height: 100vh
+  min-height: 100vh;
+  justify-content: space-between;
 }
 c-login-card {
   margin: 2rem auto;

--- a/swift_browser_ui_frontend/src/pages/IndexPage.vue
+++ b/swift_browser_ui_frontend/src/pages/IndexPage.vue
@@ -114,7 +114,8 @@ export default {
 <style>
 c-main { 
   height: unset; 
-  min-height: 100vh 
+  min-height: 100vh;
+  justify-content: space-between;
 }
 
 c-card {

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -70,7 +70,8 @@
 <style>
 c-main {
   height: unset;
-  min-height: 100vh
+  min-height: 100vh;
+  justify-content: space-between;
 }
 c-login-card {
   margin: 2rem auto;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
After https://github.com/CSCfi/swift-browser-ui/pull/952, the footer was not necessarily sticking to the bottom, but only noticeable in larger screens.

This makes the middle content expand as much as possible, pushing the footer to the bottom.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Add `flex-grow: 1;` to the main content (`c-row`) in the login pages


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
