### PR TITLE
Use new OIDC in OIDC return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Use oidc login Keystone provider for automatically forwarded SSO in oidc return
 - (GH #851) Kill upload sessions upon finishing uploads to allow reuploading same files in all cases
 - (GH #884) Fixed multiple bugs
   - Redirected to AllFolders view whenever the selected project changes

--- a/swift_browser_ui/ui/login.py
+++ b/swift_browser_ui/ui/login.py
@@ -98,8 +98,9 @@ async def oidc_end(request: aiohttp.web.Request) -> aiohttp.web.Response:
     )
 
     if session["oidc"]["userinfo"].get("homeFederation", "") == "Haka":
-        response.headers["Location"] = HAKA_ENDPOINT(
+        response.headers["Location"] = HAKA_OIDC_ENDPOINT(
             endpoint=str(setd["auth_endpoint_url"]),
+            oidc=str(setd["keystone_oidc_provider"]),
             origin=str(setd["set_origin_address"]),
         )
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Changing to use Keystone as a login provider also required changing the OIDC callback to use this different login provider.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Use `oidc` as Keystone login provider when automatically forwarding to login from OIDC callback.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
