### PR TITLE
Fix missing footer and language-selector component setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix missing footer and language-selector component setup
 - Use oidc login Keystone provider for automatically forwarded SSO in oidc return
 - (GH #851) Kill upload sessions upon finishing uploads to allow reuploading same files in all cases
 - (GH #884) Fixed multiple bugs

--- a/swift_browser_ui_frontend/src/entries/badrequest.js
+++ b/swift_browser_ui_frontend/src/entries/badrequest.js
@@ -10,6 +10,7 @@ import cModel from "@/common/csc-ui.js";
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 import { vControlV2 } from "csc-ui-vue-directive";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
@@ -36,6 +37,7 @@ new Vue({
   name: "BadRequest",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/forbid.js
+++ b/swift_browser_ui_frontend/src/entries/forbid.js
@@ -10,6 +10,7 @@ import cModel from "@/common/csc-ui.js";
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 import { vControlV2 } from "csc-ui-vue-directive";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
@@ -36,6 +37,7 @@ new Vue({
   name: "ForbiddenPage",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/index.js
+++ b/swift_browser_ui_frontend/src/entries/index.js
@@ -10,6 +10,7 @@ import cModel from "@/common/csc-ui.js";
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 import { vControlV2 } from "csc-ui-vue-directive";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
@@ -36,6 +37,7 @@ new Vue({
   name: "IndexPage",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/index_oidc.js
+++ b/swift_browser_ui_frontend/src/entries/index_oidc.js
@@ -9,7 +9,11 @@ import checkIDB from "@/common/idb_support";
 import cModel from "@/common/csc-ui.js";
 
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
+import { vControlV2 } from "csc-ui-vue-directive";
 import VueI18n from "vue-i18n";
+
+import CFooter from "@/components/CFooter.vue";
+import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
 import "@/css/prod.scss";
@@ -22,7 +26,8 @@ applyPolyfills().then(() => {
 });
 
 Vue.use(VueI18n);
-
+Vue.directive("control", vControlV2);
+Vue.directive("csc-model", cModel);
 
 const i18n = new VueI18n({
   locale: getLangCookie(),
@@ -31,6 +36,10 @@ const i18n = new VueI18n({
 
 new Vue ({
   i18n,
+  components: {
+    CFooter,
+    LanguageSelector,
+  },
   data: {
     loading: false,
     idb: true,
@@ -57,6 +66,3 @@ new Vue ({
   },
   ...App,
 }).$mount("#app");
-
-
-Vue.directive("csc-model", cModel);

--- a/swift_browser_ui_frontend/src/entries/loginpassword.js
+++ b/swift_browser_ui_frontend/src/entries/loginpassword.js
@@ -5,6 +5,7 @@ import VueI18n from "vue-i18n";
 import getLangCookie from "@/common/conv";
 import translations from "@/common/lang";
 
+import CFooter from "@/components/CFooter.vue";
 import cModel from "@/common/csc-ui.js";
 
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
@@ -36,6 +37,7 @@ new Vue({
   name: "LoginPassword",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/notfound.js
+++ b/swift_browser_ui_frontend/src/entries/notfound.js
@@ -10,6 +10,7 @@ import cModel from "@/common/csc-ui.js";
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 import { vControlV2 } from "csc-ui-vue-directive";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
@@ -36,6 +37,7 @@ new Vue({
   name: "NotfoundPage",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/uidown.js
+++ b/swift_browser_ui_frontend/src/entries/uidown.js
@@ -10,6 +10,7 @@ import cModel from "@/common/csc-ui.js";
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 import { vControlV2 } from "csc-ui-vue-directive";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 // Import project css
@@ -36,6 +37,7 @@ new Vue({
   name: "ServiceUnavailable",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/entries/unauth.js
+++ b/swift_browser_ui_frontend/src/entries/unauth.js
@@ -9,6 +9,7 @@ import cModel from "@/common/csc-ui.js";
 
 import { applyPolyfills, defineCustomElements } from "csc-ui/dist/loader";
 
+import CFooter from "@/components/CFooter.vue";
 import LanguageSelector from "@/components/CLanguageSelector.vue";
 import { vControlV2 } from "csc-ui-vue-directive";
 
@@ -36,6 +37,7 @@ new Vue({
   name: "UnauthorizedPage",
   i18n,
   components: {
+    CFooter,
     LanguageSelector,
   },
   data: {

--- a/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
+++ b/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
@@ -4,6 +4,7 @@
       <c-csc-logo />
       {{ $t('message.program_name') }}
       <c-spacer />
+      <LanguageSelector />
     </c-toolbar>
     <c-row>
       <c-flex>
@@ -39,6 +40,7 @@
         </c-container>
       </c-flex>
     </c-row>
+    <CFooter />
   </c-main>
 </template>
 

--- a/swift_browser_ui_frontend/src/pages/IndexPage.vue
+++ b/swift_browser_ui_frontend/src/pages/IndexPage.vue
@@ -100,10 +100,12 @@
 <script>
 import checkIDB from "@/common/idb_support";
 import CFooter from "@/components/CFooter.vue";
+import LanguageSelector from "@/components/CLanguageSelector.vue";
 
 export default {
   components:{
     CFooter,
+    LanguageSelector,
   },
   mounted: function () {
     checkIDB().then(result => this.idb = result);


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Fix footer and language selector not showing up in index, login and error pages.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Added footer and language-selector component setup where missing
- Added missing footer and language-selector components to templates

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
@blankdots, thanks for bringing it to light