### PR TITLE
Changed private browsing error msg and appearance #922

### DIFF
--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -39,6 +39,7 @@ etsittyä
 että
 etusivulle
 etusivun
+Firefoxin
 hakea
 haku
 hakuindeksi
@@ -144,6 +145,7 @@ kestää
 kiellettyä
 kiinni
 kirjaudu
+kirjautua
 kirjautuaksesi
 kirjautumalla
 kirjautuminen
@@ -269,6 +271,7 @@ ohjeet
 oikeuden
 oikeudet
 oikeuksia
+ole
 olemassa
 olet
 oletusarvoisesti
@@ -386,6 +389,7 @@ sallittu
 se
 sekunnin
 selaamiseen
+selaamisesta
 selailla
 selailu
 selaimestasi
@@ -393,6 +397,7 @@ selaimet
 selain
 selainta
 selatessa
+selaus
 sen
 seuraava
 siirry
@@ -472,6 +477,7 @@ toiminto
 toiseen
 toisen
 toisesta
+toista
 toteuttaa
 tueta
 tuettu
@@ -501,6 +507,7 @@ uusi
 uusia
 vaatii
 vähintään
+vaihda
 vaihto
 väliaikaiseen
 valikkoon
@@ -525,16 +532,18 @@ virhe
 virheellinen
 voi
 voida
+voidaksesi
 voit
 voivat
 vuoksi
 yhdelle
 yhden
+yhtään
 yhteenlaskettu
 yhteys
-yhtään
 yksityinen
 yksityisen
+yksityisestä
 yksityiskohtia
 yksityistä
 yli

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -46,10 +46,9 @@ let default_translations = {
         inUse: "Bucket name already in use.",
         invalidName: "Bucket name is invalid.",
         createFail: "Bucket creation failed.",
-        idb: "Browser not supported.",
+        idb: "Private mode not supported.",
         idb_text:
-          "This browser is not supported.\n" +
-          "Please, use a supported browser.",
+          "Please switch private mode off to enable login to SD Connect.",    
       },
       dropFiles: "Drag and drop folders here or ",
       help: "Help",
@@ -511,8 +510,9 @@ let default_translations = {
         inUse: "Säiliön nimi on jo käytössä.",
         invalidName: "Säiliön nimi ei kelpaa.",
         createFail: "Säiliön luonti epäonnistui.",
-        idb: "Selain ei tuettu.",
-        idb_text: "Tätä selainta ei tueta. Käytä tuettua selainta.",
+        idb: "Yksityinen selaaminen ei ole tuettu.",
+        idb_text:
+          "Voidaksesi kirjautua vaihda pois yksityisestä selaamisesta.",
       },
       dropFiles: "Vedä ja pudota kansiot tähän tai ",
       help: "Apua",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -46,9 +46,11 @@ let default_translations = {
         inUse: "Bucket name already in use.",
         invalidName: "Bucket name is invalid.",
         createFail: "Bucket creation failed.",
-        idb: "Private mode not supported.",
+        idb: "Firefox in private mode is not supported.",
         idb_text:
-          "Please switch private mode off to enable login to SD Connect.",    
+          "Firefox is not supported in private mode. " +
+          "To continue, please turn off Firefox's private browsing or " +
+          "switch to another browser.",
       },
       dropFiles: "Drag and drop folders here or ",
       help: "Help",
@@ -510,9 +512,11 @@ let default_translations = {
         inUse: "Säiliön nimi on jo käytössä.",
         invalidName: "Säiliön nimi ei kelpaa.",
         createFail: "Säiliön luonti epäonnistui.",
-        idb: "Yksityinen selaaminen ei ole tuettu.",
+        idb: "Firefoxin yksityinen selaus ei ole tuettu.",
         idb_text:
-          "Voidaksesi kirjautua vaihda pois yksityisestä selaamisesta.",
+          "Firefoxin yksityinen selaus ei ole tuettu." +
+          "Voidaksesi kirjautua vaihda pois yksityisestä selaamisesta " +
+          "tai käytä toista selainta.",
       },
       dropFiles: "Vedä ja pudota kansiot tähän tai ",
       help: "Apua",

--- a/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
+++ b/swift_browser_ui_frontend/src/pages/IndexOIDCPage.vue
@@ -12,6 +12,9 @@
             <c-login-card
               :src="require('@/assets/banner_login.png')"
             >
+              <c-alert type="error" v-if="!idb">
+                <p>{{ $t('message.error.idb_text') }}</p>
+              </c-alert>
               <c-login-card-title>
                 {{ $t('message.program_name') }}
               </c-login-card-title>
@@ -29,11 +32,6 @@
                   {{ $t('message.indexOIDC.logIn') }}
                 </c-button>
               </c-login-card-actions>
-              <c-login-card-content v-if="!idb">
-                <p>
-                  <strong>{{ $t('message.error.idb') }}</strong>
-                </p>
-              </c-login-card-content>
             </c-login-card>
           </form>
         </c-container>

--- a/swift_browser_ui_frontend/src/pages/LoginPassword.vue
+++ b/swift_browser_ui_frontend/src/pages/LoginPassword.vue
@@ -20,6 +20,9 @@
             <c-login-card
               :src="require('@/assets/banner_login.png')"
             >
+              <c-alert type="error" v-if="!idb">
+                <p>{{ $t('message.error.idb_text') }}</p>
+              </c-alert>
               <c-login-card-title>
                 {{ $t('message.pwdlogin.header') }}
               </c-login-card-title>
@@ -53,11 +56,6 @@
                   style="display:none"
                 >
               </c-login-card-actions>
-              <c-login-card-content v-if="!idb">
-                <p>
-                  <strong>{{ $t('message.error.idb') }}</strong>
-                </p>
-              </c-login-card-content>
             </c-login-card>
           </form>
         </c-container>


### PR DESCRIPTION
### Related issues
[Issue: Login page / Replace "﻿Browser not supported" more informative text #922
](https://gitlab.ci.csc.fi/sds-dev/sd-connect/swift-browser-ui/-/issues/922)

### Changes Made

- Changed "Browser not supported" to what's provided on Figma 
- Liisa provided a Finnish translation for it
- Changed the element from <c-login-card-content> to <c-alert> to best reflect the design on figma

