### PR TITLE
Bumped spellcheck version to lastest release 0.30.0

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: rojopolis/spellcheck-github-actions@0.22.1
+    - uses: rojopolis/spellcheck-github-actions@0.30.0
       name: Spellcheck
       with:
         config_path: .github/config/.spellcheck.yml


### PR DESCRIPTION
### Description

Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am _sunsetting_ version 0.22.1 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.30.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

jonasbn

### Related issues

None

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [X] Infrastructure change

### Changes Made

Bump of currently used version of Spellcheck action from version 0.22.1 to 0.30.0

### Testing

- [X] Tests do not apply

But a succesfull run of the updated action, demonstrating no regression would be nice

### Mentions

Thanks for using the spellcheck action

