### PR TITLE
Add workflow for updating pnpm packages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Documentation check
 
-on: [push]
+on: [pull_request]
 
 jobs:
   style_check:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,6 @@
 name: Javascript ESLint check
 
-on: [push]
+on: [pull_request]
 
 
 jobs:

--- a/.github/workflows/pnpm-autoupdate.yml
+++ b/.github/workflows/pnpm-autoupdate.yml
@@ -1,0 +1,44 @@
+name: PNPM auto update packages
+
+on: 
+  pull_request:
+    branches: [devel]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['18']
+    name: pnpm packages update
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+          cache-dependency-path: swift_browser_ui_frontend/pnpm-lock.yaml
+      - name: Install dependencies
+        run: |
+          pushd swift_browser_ui_frontend
+          pnpm update
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update pnpm packages
+          title: pnpm package updates
+          body: |
+            Automated PR with PNPM updates
+
+            Close and re-open this PR for the checks to run.
+          branch: update/pnpm-updates
+          base: devel

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,6 @@
 name: Spelling Errors Check
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,6 @@
 name: Python style check
 
-on: [push]
+on: [pull_request]
 
 jobs:
   style_check:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,6 @@
 name: Python Unit Tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   unit_test:

--- a/.github/workflows/vueunit.yml
+++ b/.github/workflows/vueunit.yml
@@ -1,6 +1,6 @@
 name: Vue.js Unit Tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Dependabot doesn't update `pnpm` packages, so here's an action to create a PR with `pnpm` updates.

It's not perfect, though.
1. It runs when a new PR is created, as cron jobs only run on the default branch
2. It uses `GITHUB_TOKEN`, so the new PR doesn't trigger other workflows
3. PR has to be closed and opened again to run checks

More info:
- https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
- https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-update-x-periodically

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Added a new github workflow for automatically updating pnpm packages
- Change workflows from `push` to `pull_request`, so that checks run in the automated PR

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
