### PR TITLE
Replace buefy components with csc-ui components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #1014) Replace buefy snackbars with custom c-toasts from `csc-ui`
 - (GL #944) Replace buefy b-input with c-text-field from `csc-ui`
 - (GL #944) Replace buefy b-button with c-button from `csc-ui`
+- (GL #944) Replace buefy b-select with c-select from `csc-ui`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GL #944) Replace buefy b-button with c-button from `csc-ui`
 - (GL #944) Replace buefy b-select with c-select from `csc-ui`
 - (GL #944) Replace buefy b-loading with c-loader from `csc-ui` and remove unused b-loading
+- (GL #944) Replace buefy b-table with c-data-table from `csc-ui`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GL #944) Replace buefy b-input with c-text-field from `csc-ui`
 - (GL #944) Replace buefy b-button with c-button from `csc-ui`
 - (GL #944) Replace buefy b-select with c-select from `csc-ui`
+- (GL #944) Replace buefy b-loading with c-loader from `csc-ui` and remove unused b-loading
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #1007) Create new Taginput component to replace Buefy's taginput component
 - (GH #1009) Replace buefy toasts with c-toasts from `csc-ui`
 - (GH #1014) Replace buefy snackbars with custom c-toasts from `csc-ui`
+- (GL #944) Replace buefy b-input with c-text-field from `csc-ui`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #1009) Replace buefy toasts with c-toasts from `csc-ui`
 - (GH #1014) Replace buefy snackbars with custom c-toasts from `csc-ui`
 - (GL #944) Replace buefy b-input with c-text-field from `csc-ui`
+- (GL #944) Replace buefy b-button with c-button from `csc-ui`
 
 ### Fixed
 

--- a/swift_browser_ui_frontend/src/common/store.js
+++ b/swift_browser_ui_frontend/src/common/store.js
@@ -23,8 +23,6 @@ const store = new Vuex.Store({
     active: {},
     uname: "",
     multipleProjects: false,
-    isLoading: false,
-    isFullPage: true,
     objectCache: [], // Only for shared objects
     langs: [
       { ph: "In English", value: "en" },
@@ -59,9 +57,6 @@ const store = new Vuex.Store({
     uploadAbort: undefined,
   },
   mutations: {
-    loading(state, payload) {
-      state.isLoading = payload;
-    },
     updateObjects(state, objects) {
       // Update object cache with the new object listing.
       state.objectCache = [...objects];
@@ -85,9 +80,6 @@ const store = new Vuex.Store({
     setUname(state, newUname) {
       // Update the username in store
       state.uname = newUname;
-    },
-    setLoading(state, newValue) {
-      state.isLoading = newValue;
     },
     setSharingClient(state, newClient) {
       state.client = newClient;
@@ -248,24 +240,18 @@ const store = new Vuex.Store({
   },
   actions: {
     updateContainers: async function (
-      { state, commit, dispatch },
+      { state, dispatch },
       { projectID, signal },
     ) {
       const existingContainers = await state.db.containers
         .where({ projectID })
         .toArray();
-      if (existingContainers.length === 0) {
-        commit("loading", true);
-      }
       let containers;
       let marker = "";
       let newContainers = [];
       do {
         containers = [];
-        containers = await getContainers(projectID, marker).catch(() => {
-          commit("loading", false);
-        });
-        commit("loading", false);
+        containers = await getContainers(projectID, marker).catch(() => {});
         if (containers.length > 0) {
           containers.forEach(cont => {
             cont.tokens = tokenize(cont.name);
@@ -494,7 +480,6 @@ const store = new Vuex.Store({
       { commit, dispatch },
       { project, owner, container, signal },
     ) {
-      commit("loading", true);
       let sharedObjects = [];
       let marker = "";
       let objects = [];
@@ -507,7 +492,6 @@ const store = new Vuex.Store({
           true,
           owner,
         ).catch(() => {
-          commit("loading", false);
           commit("updateObjects", []);
         });
 
@@ -516,7 +500,6 @@ const store = new Vuex.Store({
           marker = objects[objects.length - 1].name;
         }
       } while (objects.length > 0);
-      commit("loading", false);
       commit("updateObjects", sharedObjects);
       dispatch("updateObjectTags", {
         projectID: project,

--- a/swift_browser_ui_frontend/src/components/CopyFolderModal.vue
+++ b/swift_browser_ui_frontend/src/components/CopyFolderModal.vue
@@ -15,23 +15,17 @@
             {{ $t("message.replicate.destinationExists") }}
           </p>
         </c-alert>
-        <b-field
-          custom-class="has-text-dark"
+        <c-text-field
+          id="new-copy-folderName"
+          v-csc-model="folderName"
           :label="$t('message.replicate.name_newFolder')"
-          label-for="new-copy-folderName"
-        >
-          <b-input
-            id="new-copy-folderName"
-            v-model="folderName"
-            name="foldername"
-            custom-class="has-text-dark"
-            :loading="loadingFoldername"
-          />
-        </b-field>
+          name="foldername"
+          :loading="loadingFoldername"
+        />
         <label
           class="taginput-label"
           label-for="copy-folder-taginput"
-        >
+        >  
           {{ $t('message.tagName') }}
         </label>
         <TagInput

--- a/swift_browser_ui_frontend/src/components/CreateFolderModal.vue
+++ b/swift_browser_ui_frontend/src/components/CreateFolderModal.vue
@@ -17,19 +17,14 @@
         <p class="info-text is-size-6">
           {{ $t("message.container_ops.norename") }}
         </p>
-        <b-field
-          custom-class="has-text-dark"
+        <c-text-field
+          id="folderName"
+          v-csc-model="folderName"
           :label="$t('message.container_ops.folderName')"
-          label-for="folderName"
-        >
-          <b-input
-            id="folderName"
-            v-model="folderName"
-            name="foldername"
-            aria-required="true"
-            data-testid="folder-name"
-          />
-        </b-field>
+          name="foldername"
+          aria-required="true"
+          data-testid="folder-name"
+        />
         <label
           class="taginput-label"
           label-for="create-folder-taginput"

--- a/swift_browser_ui_frontend/src/components/ObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/ObjectTable.vue
@@ -79,15 +79,18 @@
       id="optionsbar"
       justify="space-between"
     >
-      <div class="search">
-        <b-input
-          v-model="searchQuery"
-          :placeholder="$t('message.objects.filterBy')"
-          type="search"
-          icon="filter-variant"
+      <c-text-field
+        id="search"
+        v-csc-model="searchQuery"
+        name="search"
+        :placeholder="$t('message.objects.filterBy')"
+        type="search"
+      >
+        <i 
+          slot="pre" 
+          class="mdi mdi-filter-variant mdi-24px"
         />
-      </div>
-
+      </c-text-field>
       <c-menu
         :key="optionsKey"
         :items.prop="tableOptions"
@@ -763,6 +766,10 @@ export default {
 
 <style scoped lang="scss">
 @import "@/css/prod.scss";
+
+#search {
+  flex: 0.4;
+}
 
 .back-link {
   display: flex;

--- a/swift_browser_ui_frontend/src/components/SearchBox.vue
+++ b/swift_browser_ui_frontend/src/components/SearchBox.vue
@@ -31,9 +31,8 @@
           v-if="searchArray.length > 0 && searchArray[0].length > 1"
           class="media empty-search"
         >
-          <b-loading
-            v-model="isSearching"
-            :is-full-page="false"
+          <c-loader
+            v-show="isSearching"
           />
           <div
             v-show="!isSearching"

--- a/swift_browser_ui_frontend/src/components/UploadModal.vue
+++ b/swift_browser_ui_frontend/src/components/UploadModal.vue
@@ -115,11 +115,13 @@
                   rows="3"
                 />
                 <c-button
-                  type="is-success"
-                  icon-left="lock-plus"
                   @click="appendPublicKey"
                   @keyup.enter="appendPublicKey"
                 >
+                  <i
+                    slot="icon"
+                    class="mdi mdi-lock-plus"
+                  />
                   {{ $t("message.encrypt.addkey") }}
                 </c-button>
                 <c-data-table

--- a/swift_browser_ui_frontend/src/entries/main.js
+++ b/swift_browser_ui_frontend/src/entries/main.js
@@ -160,12 +160,6 @@ new Vue({
     user() {
       return this.$store.state.uname;
     },
-    isFullPage() {
-      return this.$store.state.isFullPage;
-    },
-    isLoading() {
-      return this.$store.state.isLoading;
-    },
     isChunking() {
       return this.$store.state.isChunking;
     },

--- a/swift_browser_ui_frontend/src/entries/select.js
+++ b/swift_browser_ui_frontend/src/entries/select.js
@@ -28,7 +28,7 @@ new Vue ({
     loginformname: "Openstack account:",
     idb: true,
     projects: [],
-    langs: [{ph: "In English", value: "en"}, {ph: "Suomeksi", value: "fi"}],
+    langs: [{name: "In English", value: "en"}, {name: "Suomeksi", value: "fi"}],
   },
   created() {
     document.title = this.$t("message.program_name");

--- a/swift_browser_ui_frontend/src/pages/BrowserPage.vue
+++ b/swift_browser_ui_frontend/src/pages/BrowserPage.vue
@@ -46,11 +46,6 @@
         <CopyFolderModal />
       </c-modal>
       <router-view class="content-wrapper" />
-      <b-loading
-        :is-full-page="isFullPage"
-        :active.sync="isLoading"
-        :can-cancel="false"
-      />
       <c-toasts id="toasts" />
       <!-- TODO: Move folder toast to programmatical modal -->
       <c-toasts

--- a/swift_browser_ui_frontend/src/pages/SelectPage.vue
+++ b/swift_browser_ui_frontend/src/pages/SelectPage.vue
@@ -9,26 +9,24 @@
         v-for="project in projects.filter(pro => pro.tainted)"
         :key="project.id"
       >
-        <b-button
-          tag="a"
-          expanded
+        <c-button
           :href="'/lock/'.concat(project.id)"
-          size="is-large"
-          type="is-primary is-outlined"
+          size="large"
+          outlined
+          fit
         >
           {{ project.name }}
-        </b-button>
+        </c-button>
       </p>
       <p>
-        <b-button
-          tag="a"
-          expanded
+        <c-button
           href="/lock/none"
-          size="is-large"
-          type="is-primary is-outlined"
+          size="large"
+          outlined
+          fit
         >
           {{ $t("message.select.unrestricted" ) }}
-        </b-button>
+        </c-button>
       </p>
       <p>
         <b-field class="locale-changed block center">

--- a/swift_browser_ui_frontend/src/pages/SelectPage.vue
+++ b/swift_browser_ui_frontend/src/pages/SelectPage.vue
@@ -29,23 +29,14 @@
         </c-button>
       </p>
       <p>
-        <b-field class="locale-changed block center">
-          <b-select
-            v-model="$i18n.locale"
-            placeholder="Language"
-            icon="earth"
-            expanded
-            @input="setCookieLang ()"
-          >
-            <option
-              v-for="lang in langs"
-              :key="lang.value"
-              :value="lang.value"
-            >
-              {{ lang.ph }}
-            </option>
-          </b-select>
-        </b-field>
+        <c-select
+          v-csc-model="$i18n.locale"
+          class="locale-changed block center"
+          placeholder="Language"
+          :items="langs"
+          fit
+          @input="setCookieLang ()"
+        />
       </p>
     </div>
   </div>

--- a/swift_browser_ui_frontend/src/views/Tokens.vue
+++ b/swift_browser_ui_frontend/src/views/Tokens.vue
@@ -12,17 +12,13 @@
           {{ $t('message.tokens.back') }}
         </router-link>
       </section>
-      <b-field grouped>
-        <b-field
-          :label="$t('message.tokens.identLabel')"
-          :message="$t('message.tokens.identMessage')"
-          expanded
-        >
-          <b-input
-            v-model="newIdentifier"
-            name="newIdentifier"
-            expanded
-          />
+      <c-text-field
+        v-csc-model="newIdentifier"
+        name="newIdentifier"
+        :label="$t('message.tokens.identLabel')"
+        :hint="$t('message.tokens.identMessage')"
+        fit
+      />
 
           <p
             id="submitButton"

--- a/swift_browser_ui_frontend/src/views/Tokens.vue
+++ b/swift_browser_ui_frontend/src/views/Tokens.vue
@@ -20,27 +20,20 @@
         fit
       />
 
-          <p
-            id="submitButton"
-            class="control"
-          >
-            <button
-              v-if="tokenExists(newIdentifier)"
-              class="button is-primary"
-              disabled
-            >
-              {{ $t('message.tokens.createToken') }}
-            </button>
-            <button
-              v-else
-              class="button is-primary"
-              @click="addToken(newIdentifier)"
-            >
-              {{ $t('message.tokens.createToken') }}
-            </button>
-          </p>
-        </b-field>
-      </b-field>
+      <c-row gap="8">
+        <c-button
+          v-if="tokenExists(newIdentifier)"
+          disabled
+        >
+          {{ $t('message.tokens.createToken') }}
+        </c-button>
+        <c-button
+          v-else
+          @click="addToken(newIdentifier)"
+        >
+          {{ $t('message.tokens.createToken') }}
+        </c-button>
+      </c-row>
     </div>
     <div
       v-if="latest"
@@ -50,14 +43,17 @@
         <span>
           <b>{{ $t('message.tokens.latestToken') }}</b>&nbsp;{{ latest }}&nbsp;
         </span>
-        <b-button
+        <c-button
           class="copyButton"
           outlined
-          icon-left="content-copy"
           @click="copyTokenHex()"
         >
+          <i
+            slot="icon"
+            class="mdi mdi-content-copy"
+          />
           {{ $t('message.copy') }}
-        </b-button>
+        </c-button>
       </div>
     </div>
     <b-table
@@ -83,27 +79,35 @@
         <template #default="props">
           <div class="field has-addons">
             <p class="control">
-              <b-button
+              <!-- How can i apply 'type="is-danger"'? -->
+              <!-- Also, what's the difference between the buttons? -->
+              <c-button
                 v-if="selected==props.row"
                 type="is-danger"
-                icon-left="delete"
                 outlined
-                size="is-small"
+                size="small"
                 inverted
                 @click="removeToken(props.row)"
               >
+                <i
+                  slot="icon"
+                  class="mdi mdi-delete"
+                />
                 {{ $t('message.tokens.revoke') }}
-              </b-button>
-              <b-button
+              </c-button>
+              <c-button
                 v-else
                 type="is-danger"
-                icon-left="delete"
                 outlined
-                size="is-small"
+                size="small"
                 @click="removeToken(props.row)"
               >
+                <i
+                  slot="icon"
+                  class="mdi mdi-delete"
+                />
                 {{ $t('message.tokens.revoke') }}
-              </b-button>
+              </c-button>
             </p>
           </div>
         </template>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Many of buefy components used could already be changed to use `csc-ui` components.

### Changes Made

<!-- List changes made. -->
- Replace buefy b-input with c-text-field from `csc-ui`
- Replace buefy b-button with c-button from `csc-ui`
- Replace buefy b-select with c-select from `csc-ui`
- Replace buefy b-loading with c-loader and remove unused b-loading
- Replace buefy b-table with c-data-table from `csc-ui`


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply
- [ ] Manually test changed functionality. Changed components
  - [ ] `CopyFolderModal.vue` - input fields
  - [ ] `CreateFolderModal.vue` - input fields
  - [ ] `ObjectTable.vue` - search box
  - [ ] `SelectPage.vue` - text input, dropdown, buttons
  - [ ] `Tokens.vue` - text input, dropdown, buttons, data table


### Mentions
As pointed out by @blankdots, buefy text fields look quite different from csc-ui, as csc-ui text fields look like the ones in material design from Google.

cc @hannyle, @ainoc 

- csc-ui
![image](https://user-images.githubusercontent.com/93575941/223680397-bbfe9298-6a93-46f3-b3ee-c9232d0ffcfc.png)
- buefy
![image](https://user-images.githubusercontent.com/93575941/223680625-7ef43a23-8256-42ce-abc0-a7b8bed530ac.png)
