### PR TITLE
Fix for empty Shared folders

### DIFF
--- a/swift_browser_ui_frontend/src/components/ShareModal.vue
+++ b/swift_browser_ui_frontend/src/components/ShareModal.vue
@@ -34,7 +34,7 @@
           </h3>
           <c-flex
             class="toggle-instructions"
-            :aria-label="$t('shareid_instructions')"
+            :aria-label="$t('label.shareid_instructions')"
             @click="toggleShareGuide"
             @keyup.enter="toggleShareGuide"
           >
@@ -66,8 +66,8 @@
         </ul>
         <TagInput
           :tags="tags"
-          :aria-label="$t('label.list_of_shareids')"
-          :placeholder="$t('message.share.field_placeholder')"
+          aria-label="label.list_of_shareids"
+          placeholder="message.share.field_placeholder"
           @addTag="addingTag"
           @deleteTag="deletingTag"
         />

--- a/swift_browser_ui_frontend/src/components/TagInput.vue
+++ b/swift_browser_ui_frontend/src/components/TagInput.vue
@@ -8,7 +8,7 @@
       :key="tag"
       active
     >
-      {{ tag }}
+      <span>{{ tag }}</span>
       <c-icon
         :path="mdiClose"
         :alt="$t('label.delete_tag')"
@@ -18,10 +18,8 @@
       />
     </c-tag>
     <input
-      id="tag-input"
       type="text"
       :aria-label="$t('label.edit_tag')"
-      maxlength="20"
       :placeholder="$t(placeholder)"
       @blur="$emit('addTag', $event, true)"
       @keydown="$emit('addTag', $event)"
@@ -80,5 +78,12 @@ export default {
   border: none;
   outline: none;
   flex: 1;
+}
+
+span {
+  display: inline-block;
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
### Description

The input field in new TagInput component has a limit of only 20 chars. This cut off the Share ID chars when pasting it in the Share ID field in Share Modal, and the result was an empty Shared Folder array.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Removed limit for input field
- Showed overflow text as ellipsis

### Testing

- [x] Needs testing (manual test)

