### PR TITLE
switch to redis library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GL #944) Replace buefy b-select with c-select from `csc-ui`
 - (GL #944) Replace buefy b-loading with c-loader from `csc-ui` and remove unused b-loading
 - (GL #944) Replace buefy b-table with c-data-table from `csc-ui`
-- (GL #944) Replace buefy dialogs with c-modal from `csc-ui`
+- (GH #1028) Switch from `aioredis` to `redis` library due to deprecation
+- (GH #1025) add timeout to `requests` as recommended by `bandit`
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "aiohttp-session==2.12.0",
     "aiohttp==3.8.4",
-    "aioredis==2.0.1",
+    "redis==4.5.1",
     "asyncpg==0.27.0",
     "certifi==2022.12.7",
     "click==8.1.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.4
 aiohttp-session==2.12.0
-aioredis==2.0.1
+redis==4.5.1
 asyncpg==0.27.0
 certifi==2022.12.7
 click==8.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     mypy
     types-requests
     types-certifi
+    types-redis
 # Mypy fails if 3rd party library doesn't have type hints configured.
 # Alternative to ignoring imports would be to write custom stub files, which
 # could be done at some point.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

according to https://github.com/aio-libs/aioredis-py `aioredis` was included in `redis-py` so we should switch to maintained library

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New library (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- switch from `aioredis` to `redis` as `aioredis` is deprecated

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
changelog also contains something that was not added in #1025 

~I am leaving this in draft till i get to test it.~