### PR TITLE
Replace b-upload with a new component CUploadButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #969) Automate building wasm with npm
 - (GH #983) Make elements more semantic and improve accessibility for screen reader users
 - (GH #989) Make selected Display Options consistent when browsing between pages
+- (GL #944) Replace buefy upload button with a new component: `CUploadButton`
 
 ### Changed
 

--- a/swift_browser_ui_frontend/src/components/CUploadButton.vue
+++ b/swift_browser_ui_frontend/src/components/CUploadButton.vue
@@ -1,0 +1,70 @@
+Inspired by https://github.com/buefy/buefy/blob/3b3ae60e448ddfd669f20570d40812fd1e041473/src/components/upload/Upload.vue
+
+<template>
+  <div class="upload-btn-wrapper">
+    <c-button 
+      @click="$refs.input.click()"
+      @keyup.enter="$refs.input.click()"
+    >
+      <slot />
+    </c-button>
+    <input
+      ref="input"
+      type="file"
+      v-bind="$attrs"
+      multiple 
+      @change="onFileChange"
+    >
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CUploadButton",
+  inheritAttrs: false,
+  props: {
+    value: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      newValue: this.value,
+    };
+  },
+  watch: {
+    value(value) {
+      this.newValue = value;
+      if (!value || (Array.isArray(value) && value.length === 0)) {
+        this.$refs.input.value = null;
+      }
+    },
+  },
+  methods: {
+    onFileChange(event) {
+      const value = event.target.files || event.dataTransfer.files;
+      if (value.length === 0) {
+        if (!this.newValue) return;
+      } else {
+        let newValues = false;
+        for (let i = 0; i < value.length; i++) {
+          const file = value[i];
+          this.newValue.push(file);
+          newValues = true;
+        }
+        if (!newValues) return;
+      }
+      this.$emit("input", this.newValue);
+    },
+  },
+};
+</script>
+
+<style>
+
+input {
+  display: none;
+}
+
+</style>

--- a/swift_browser_ui_frontend/src/components/UploadModal.vue
+++ b/swift_browser_ui_frontend/src/components/UploadModal.vue
@@ -40,16 +40,13 @@
           @drop="navUpload"
         >
           <span>{{ $t("message.dropFiles") }}</span>
-          <b-upload
+          <CUploadButton
             v-model="files"
-            multiple
-            accept
-            class="file is-primary"
           >
-            <span class="file-cta">
+            <span>
               {{ $t("message.encrypt.dropMsg") }}
             </span>
-          </b-upload>
+          </CUploadButton>
         </div>
         <c-data-table
           v-if="dropFiles.length > 0"
@@ -172,11 +169,15 @@ import {
   modifyBrowserPageStyles,
   getProjectNumber,
 } from "@/common/globalFunctions";
+import CUploadButton from "@/components/CUploadButton.vue";
 
 import delay from "lodash/delay";
 
 export default {
   name: "UploadModal",
+  components: {
+    CUploadButton,
+  },
   filters: {
     truncate,
   },
@@ -196,6 +197,7 @@ export default {
       recvHashedKeys: [],
       noUpload: true,
       projectNumber: "",
+      CUploadButton,
     };
   },
   computed: {


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
Part of migrating away from `buefy`, replaces `b-upload` with a new component.

I like this approach because it uses `c-button`, but when the file picker opens, it doesn't have focus, which is a bit weird.
### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Create a new upload button component: `CUploadButton`
- Replace `b-upload` with `CUploadButton`

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
