### PR TITLE
make dockerfiles build pyproject.toml

### DIFF
--- a/dockerfiles/Dockerfile-request
+++ b/dockerfiles/Dockerfile-request
@@ -4,6 +4,10 @@ COPY pyproject.toml /root/swift_request/pyproject.toml
 COPY README.md /root/swift_request/README.md
 COPY swift_browser_ui /root/swift_request/swift_browser_ui
 
+# remove this link as it creates issues with hatch
+# in pyproject.toml
+RUN rm /root/swift_request/swift_browser_ui/ui/static
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \
     && pip install /root/swift_request

--- a/dockerfiles/Dockerfile-runner
+++ b/dockerfiles/Dockerfile-runner
@@ -4,6 +4,10 @@ COPY pyproject.toml /root/swift_upload_runner/pyproject.toml
 COPY README.md /root/swift_upload_runner/README.md
 COPY swift_browser_ui /root/swift_upload_runner/swift_browser_ui
 
+# remove this link as it creates issues with hatch
+# in pyproject.toml
+RUN rm /root/swift_upload_runner/swift_browser_ui/ui/static
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \
     && pip install /root/swift_upload_runner

--- a/dockerfiles/Dockerfile-sharing
+++ b/dockerfiles/Dockerfile-sharing
@@ -4,6 +4,10 @@ COPY pyproject.toml /root/swift_sharing/pyproject.toml
 COPY README.md /root/swift_sharing/README.md
 COPY swift_browser_ui /root/swift_sharing/swift_browser_ui
 
+# remove this link as it creates issues with hatch
+# in pyproject.toml
+RUN rm /root/swift_sharing/swift_browser_ui/ui/static
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \
     && pip install /root/swift_sharing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "swift-browser-ui"
 dynamic = ["version"]
 description = "Object browser Web UI for Openstack Swift API"
 readme = "README.md"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     { name = "CSC Developers" },
@@ -67,6 +68,7 @@ swift-x-account-sharing = "swift_browser_ui.launcher:run_sharing"
 
 [project.urls]
 Source = "https://github.com/CSCfi/swift-browser-ui"
+Documentation = "https://swift-browser-ui.readthedocs.io"
 
 [tool.hatch.version]
 path = "swift_browser_ui/__init__.py"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Using `hatch` as a build tool seems to have issues with finding the symbolic link of the static folder (and seems poetry has similar issues). Switching to setuptools seems to create more issues, so trying the next best thing which is remove the symbolic link from dockerfiles.

This was introduced in: https://github.com/CSCfi/swift-browser-ui/pull/984

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- small additions in `pyproject.toml`
- remove `static` folder from dockefiles so that build can happen normally

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
