### PR TITLE
fix libupload and websocket with tls proxy

### DIFF
--- a/devproxy/nginx.conf
+++ b/devproxy/nginx.conf
@@ -93,27 +93,11 @@ http {
 			proxy_pass http://app_server_front/ws;
 		}
 
-		location /libupload.js {
-			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-			proxy_set_header X-Forwarded-Proto $scheme;
-			proxy_set_header Host $http_host;
-			proxy_redirect off;
-			proxy_buffering off;
-			proxy_pass http://app_server_front/static/libupload.js;
-		}
-
-		location /libupload.wasm {
-			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-			proxy_set_header X-Forwarded-Proto $scheme;
-			proxy_set_header Host $http_host;
-			proxy_redirect off;
-			proxy_buffering off;
-			proxy_pass http://app_server_front/static/libupload.wasm;
-		}
-
 		location / {
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "Upgrade";
 			proxy_set_header Host $http_host;
 			proxy_redirect off;
 			proxy_buffering off;

--- a/swift_browser_ui_frontend/vite.config.js
+++ b/swift_browser_ui_frontend/vite.config.js
@@ -28,6 +28,8 @@ const proxyTo = {
 
 const oidcEnabled = process.env.OIDC_ENABLED === "True";
 const root = path.resolve(__dirname, "src");
+const publicDir = path.resolve(__dirname, "public");
+
 let pages = {
   "index":         path.resolve(root, "index.html"),
   "select":        path.resolve(root, "select.html"),
@@ -48,7 +50,6 @@ let proxy = {
   "/static/assets":       proxyTo,
   "/api":                 proxyTo,
   "/discover":            proxyTo,
-  "/libupload":           proxyTo,
   "/login/oidc":          proxyTo,
   "/login/oidc_front":    proxyTo,
   "/login/oidc-redirect": proxyTo,
@@ -61,11 +62,9 @@ let proxy = {
   "/sign":                proxyTo,
   "/replicate":           proxyTo,
   "/token":               proxyTo,
-  "/ws": {
-    target: `ws${process.env.SWIFT_UI_SECURE_WEBSOCKET}://${process.env.SWIFT_UI_TLS_HOST}:${process.env.SWIFT_UI_TLS_PORT}/ws`,
-    ws: true,
-  },
 };
+
+let origin = `http${process.env.SWIFT_UI_SECURE_WEBSOCKET}://${process.env.SWIFT_UI_TLS_HOST}:${process.env.SWIFT_UI_TLS_PORT}`;
 
 // Vite doesn't work "out-of-the-box" with multiple SPAs
 // This middleware loads existing html pages and
@@ -131,6 +130,7 @@ export default defineConfig(({ command, mode }) => {
   return {
     root,
     base,
+    publicDir,
     appType: "mpa", // set the dev server as a multi-page app
     plugins: [
       vue(), 
@@ -153,6 +153,7 @@ export default defineConfig(({ command, mode }) => {
       https,
       strictPort: true,
       proxy,
+      origin,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Vite broke usage with the development proxy server, this adds that functionality back and fixes upload functionality.

Extends changes in #982

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
* Use `publicDir` instead of proxying `libupload.js` and `libupload.wasm` to backend
* Fix `devproxy` configuration to account for `vite` websocket location in root
* Change vite `origin` parameter to use TLS proxy as origin when relevant

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
