### PR TITLE
Fix for vue3 console warnings

### DIFF
--- a/swift_browser_ui_frontend/src/common/i18n.js
+++ b/swift_browser_ui_frontend/src/common/i18n.js
@@ -6,4 +6,5 @@ import translations from "@/common/lang";
 export const i18n = createI18n({
   locale: getLangCookie(),
   messages: translations,
+  warnHtmlMessage: false,
 });

--- a/swift_browser_ui_frontend/src/components/BrowserMainNavbar.vue
+++ b/swift_browser_ui_frontend/src/components/BrowserMainNavbar.vue
@@ -3,7 +3,7 @@
     <div class="toolbar">
       <router-link
         class="navbar-item pl-4"
-        :to="`/browse/${uname}/${active.id}`"
+        :to="{name: 'AllFolders'}"
         :aria-label="$t('label.csclogo')"
       >
         <c-csc-logo alt="CSC_Logo" />


### PR DESCRIPTION
### Description

Fix for warnings in [feature/vue3](https://github.com/CSCfi/swift-browser-ui/pull/1034)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

- Updated `<router-link>` of CSC Logo and Brand name on navigation bar
- Turned off `warnHtmlMessage` for vue-i18n, as it's set to `true` by default in [new version](https://vue-i18n.intlify.dev/guide/migration/breaking.html#change-warnhtmlinmessage-option-default-value)
