### PR TITLE
Fix for selecting and deleting subfolders and files

### DIFF
--- a/.github/config/.finnishwords.txt
+++ b/.github/config/.finnishwords.txt
@@ -370,6 +370,7 @@ poistettiin
 poistettu
 poistut
 polku
+polkuina
 postamista
 poudan
 profiili

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix hiding the pagination of data tables
 - Fix shared objects functionality: visibility, deleting, editing tags
 - URL does not strip the path, when that is present. Also small fixes to make it deployable under the same URL.
-- (GL #933) Fix selecting and mass deleting all files
+- (GL #933) Fix for selecting and mass deleting subfolders and files
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #989) Make selected Display Options consistent when browsing between pages
 - (GH #944) Create new Taginput component to replace Buefy's taginput component
 - (GL #944) Replace buefy upload button with a new component: `CUploadButton`
-<<<<<<< HEAD
 - (GL #940) Added TokenModal to replace token page
-=======
 - (GL #936) Add missing icon for subfolders
->>>>>>> af0149d3 (Update Changelog)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (GH #989) Make selected Display Options consistent when browsing between pages
 - (GH #944) Create new Taginput component to replace Buefy's taginput component
 - (GL #944) Replace buefy upload button with a new component: `CUploadButton`
+<<<<<<< HEAD
 - (GL #940) Added TokenModal to replace token page
+=======
+- (GL #936) Add missing icon for subfolders
+>>>>>>> af0149d3 (Update Changelog)
 
 ### Changed
 
@@ -119,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix hiding the pagination of data tables
 - Fix shared objects functionality: visibility, deleting, editing tags
 - URL does not strip the path, when that is present. Also small fixes to make it deployable under the same URL.
+- (GL #933) Fix selecting and mass deleting all files
 
 ### Removed
 

--- a/swift_browser_ui_frontend/src/common/globalFunctions.js
+++ b/swift_browser_ui_frontend/src/common/globalFunctions.js
@@ -88,3 +88,16 @@ export function deleteTag (event, tag, currentTags) {
   event.preventDefault();
   return currentTags.filter(el => el !== tag);
 }
+
+export function getPrefix(route) {
+  // Get current pseudofolder prefix
+  if (route.query.prefix == undefined) {
+    return "";
+  }
+  return `${route.query.prefix}/`;
+}
+
+export function isFile(path, route) {
+  // Return true if path represents a file in the active prefix context
+  return path.replace(getPrefix(route), "").match("/") ? false : true;
+}

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -107,7 +107,7 @@ let default_translations = {
       tableOptions: {
         displayOptions: "Display options",
         render: "Show as folders",
-        text: "Show as objects",
+        text: "Show as paths",
         hideTags: "Hide tags",
         showTags: "Display tags",
         hidePagination: "Hide pagination",
@@ -469,7 +469,7 @@ let default_translations = {
       tableOptions: {
         displayOptions: "Asetukset",
         render: "Näytä kansioina",
-        text: "Näytä tekstinä",
+        text: "Näytä polkuina",
         hideTags: "Piilota asiasanat",
         showTags: "Näytä asiasanat",
         hidePagination: "Piilota sivutus",

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -321,7 +321,11 @@ export default {
       };
     },
     handleSelection(event) {
-      this.$emit("selected-rows", event.detail);
+      if (event.detail.length > 0) {
+        const prefix = this.getPrefix();
+        const selectedRows = event.detail.map(item => prefix.concat(item));
+        this.$emit("selected-rows", selectedRows);
+      }
     },
     beginDownload(object) {
       this.currentDownload = new DecryptedDownloadSession(

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -34,6 +34,8 @@ import {
 
 import {
   toggleEditTagsModal,
+  isFile,
+  getPrefix,
 } from "@/common/globalFunctions";
 
 import {
@@ -61,9 +63,6 @@ export default {
     renderFolders: {
       type: Boolean,
       default: true,
-    },
-    checkedRows: {
-      default: [],
     },
   },
   data() {
@@ -130,13 +129,9 @@ export default {
     this.setHeaders();
   },
   methods: {
-    isFile: function (path) {
-      // Return true if path represents a file in the active prefix context
-      return path.replace(this.getPrefix(), "").match("/") ? false : true;
-    },
     changeFolder: function (folder) {
       this.$router.push(
-        `${window.location.pathname}?prefix=${this.getPrefix()}${folder}`,
+        `${window.location.pathname}?prefix=${getPrefix(this.$route)}${folder}`,
       );
       this.componentKey += 1;
       this.getPage();
@@ -144,7 +139,8 @@ export default {
     getFolderName: function (path) {
       // Get the name of the currently displayed pseudofolder
       let endregex = new RegExp("/.*$");
-      return path.replace(this.getPrefix(), "").replace(endregex, "");
+      return path.replace(getPrefix(this.$route), "")
+        .replace(endregex, "");
     },
     getPage: function () {
       let offset = 0;
@@ -163,10 +159,10 @@ export default {
       this.objects = this
         .objs
         .filter((obj) => {
-          return obj.name.startsWith(this.getPrefix());
+          return obj.name.startsWith(getPrefix(this.$route));
         })
         .reduce((items, item) => {
-          if (this.isFile(item.name) || !this.renderFolders) {
+          if (isFile(item.name, this.$route) || !this.renderFolders) {
             items.push(item);
           } else {
             if (items.find(el => {
@@ -193,7 +189,7 @@ export default {
           items.push({
             name: {
               value: value,
-              ...(this.renderFolders && !this.isFile(item.name) ? {
+              ...(this.renderFolders && !isFile(item.name, this.$route) ? {
                 component: {
                   tag: "c-link",
                   params: {
@@ -332,7 +328,7 @@ export default {
     },
     handleSelection(event) {
       if (event.detail.length > 0) {
-        const prefix = this.getPrefix();
+        const prefix = getPrefix(this.$route);
         const selectedRows = event.detail.map(item => prefix.concat(item));
         this.$emit("selected-rows", selectedRows);
       } else {
@@ -352,13 +348,6 @@ export default {
     },
     navDownload(url) {
       window.open(url, "_blank");
-    },
-    getPrefix() {
-      // Get current pseudofolder prefix
-      if (this.$route.query.prefix == undefined) {
-        return "";
-      }
-      return `${this.$route.query.prefix}/`;
     },
     setHeaders() {
       this.headers = [

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -36,7 +36,12 @@ import {
   toggleEditTagsModal,
 } from "@/common/globalFunctions";
 
-import { mdiTrayArrowDown, mdiPencilOutline, mdiDeleteOutline } from "@mdi/js";
+import {
+  mdiTrayArrowDown,
+  mdiPencilOutline,
+  mdiDeleteOutline,
+  mdiFolder ,
+} from "@mdi/js";
 
 export default {
   name: "CObjectTable",
@@ -194,6 +199,11 @@ export default {
                   params: {
                     href: "javascript:void(0)",
                     color: "dark-grey",
+                    path: mdiFolder,
+                    iconFill: "primary",
+                    iconStyle: {
+                      marginRight: "1rem",
+                    },
                     onClick: () => this.changeFolder(value),
                   },
                 },

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -335,6 +335,8 @@ export default {
         const prefix = this.getPrefix();
         const selectedRows = event.detail.map(item => prefix.concat(item));
         this.$emit("selected-rows", selectedRows);
+      } else {
+        this.$emit("selected-rows", event.detail);
       }
     },
     beginDownload(object) {

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -389,11 +389,6 @@ export default {
             message: this.$t("message.container_ops.deleteNote"),
           },
         );
-        this.$router.push(
-          this.$route.params.project
-            + "/"
-            + container,
-        );
       } else {
         toggleDeleteModal(null, container);
       }

--- a/swift_browser_ui_frontend/src/pages/BrowserPage.vue
+++ b/swift_browser_ui_frontend/src/pages/BrowserPage.vue
@@ -81,7 +81,7 @@
       <c-toasts
         id="container-error-toasts"
         vertical="top"
-        horizontal="right"
+        horizontal="center"
       />
     </div>
     <CFooter />
@@ -285,5 +285,9 @@ c-modal {
 .taginput-label {
   font-weight: bold;
   margin-bottom: -2rem;
+}
+
+#container-error-toasts {
+  margin-top: 50vh;
 }
 </style>


### PR DESCRIPTION
### Description

- Subfolders and files should be all selectable by checking checkbox
- Subfolders shouldn't be deleted before deleting all files inside it
- Files should be able to select and mass delete

### Related issues
GL 933 & 936 & 974

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Added folder icon for sub-folders
- Added `prefix` to file's names so the `file` names are matched when its checkbox is selected
- Changed `Display as text` to `Display as path` to make the term more understandable
- Prevented `subfolders` from being deleted when clicking `Delete` button or selecting together with `files`
- Updated Changelog

### Testing
- [x] Needs testing (manual test)

### Mention

- Since we have now `subfolders` and `files` in the same view, some notifications when selecting and deleting them are not clear enough and still not in correct timing/visual order
- The terms and text are still not so clear since we only have `objects` before, now `objects` could mean `subfolders` and `files``
--> These things should be fixed in another PR while waiting for the UI design from @ainoc 

